### PR TITLE
feat: july 2026 refresh + 11 new guides from issue backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-framework.yml
+++ b/.github/ISSUE_TEMPLATE/new-framework.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Framework Name
       description: The name of the framework
-      placeholder: e.g., Django, SvelteKit, Remix
+      placeholder: e.g., Remix, Laravel, Phoenix
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/new-platform.yml
+++ b/.github/ISSUE_TEMPLATE/new-platform.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Platform Name
       description: The name of the deployment platform
-      placeholder: e.g., Railway, Fly.io, AWS Lambda
+      placeholder: e.g., AWS Lambda, Deno Deploy, Zeabur
     validations:
       required: true
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+https://app\.netlify\.com.*
+https://www\.contributor-covenant\.org.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Free tier corrections: Fly.io (no free tier, pay-as-you-go), AWS (credits-based plan since July 2025), Netlify (credit-based plans), Upstash (500K commands/mo), Neon (100 CU-hrs), Railway (one-time trial), MongoDB Atlas (Flex replaces M2/M5)
 - Version bumps everywhere: Node 22/24, Python 3.12+, Express 5, FastAPI 0.139, actions/checkout@v7, node:24-alpine
 - README tables, decision tree, and cost comparison rebuilt from refreshed guides
+- CI: lychee link checker on every PR + weekly schedule; junk config files removed
 
 ## [1.0.0] - 2026-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.1.0] - 2026-07-06
+
+- Add 11 new guides: SvelteKit, Astro, Angular, NestJS, Go (Gin), Ruby on Rails, Turso, CockroachDB, Hetzner Cloud, Coolify, Monitoring & Logging
+- Refresh all 26 existing guides against live platform state (prices, free tiers, CLI commands, dashboard steps, links)
+- Free tier corrections: Fly.io (no free tier, pay-as-you-go), AWS (credits-based plan since July 2025), Netlify (credit-based plans), Upstash (500K commands/mo), Neon (100 CU-hrs), Railway (one-time trial), MongoDB Atlas (Flex replaces M2/M5)
+- Version bumps everywhere: Node 22/24, Python 3.12+, Express 5, FastAPI 0.139, actions/checkout@v7, node:24-alpine
+- README tables, decision tree, and cost comparison rebuilt from refreshed guides
+
 ## [1.0.0] - 2026-03-16
 
 - Add PR template for deployment guide contributions

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Whether you're deploying a React app, a FastAPI backend, or a full-stack MERN project, this repo has a battle-tested guide for it. Every guide includes actual commands, environment variable setup, custom domains, and troubleshooting.
 
-**25+ guides** | **10 platforms** | **8 frameworks** | **4 databases** | **4 reference guides**
+**37 guides** | **12 platforms** | **14 frameworks** | **6 databases** | **5 reference guides**
 
 ---
 
@@ -12,16 +12,18 @@ Whether you're deploying a React app, a FastAPI backend, or a full-stack MERN pr
 
 | Platform | Covers | Free Tier | Best For |
 |----------|--------|-----------|----------|
-| [GitHub Pages](guides/github-pages.md) | Static sites, SPAs | Unlimited | React, Vue, static HTML |
+| [GitHub Pages](guides/github-pages.md) | Static sites, SPAs | 1 GB site, 100 GB/mo (soft limits) | React, Vue, static HTML |
 | [Vercel](guides/vercel.md) | Frontend + serverless | Hobby (free) | Next.js, React, Svelte |
 | [Render](guides/render.md) | Full-stack apps | 750 hrs/mo | Node.js, Python, Docker |
-| [Railway](guides/railway.md) | Full-stack + databases | $5 credit | Any stack |
-| [Fly.io](guides/fly-io.md) | Edge computing, Docker | 3 shared VMs | Docker, Go, multi-region |
-| [Netlify](guides/netlify.md) | JAMstack, forms | 100 GB/mo | Static, serverless, forms |
+| [Railway](guides/railway.md) | Full-stack + databases | One-time $5 trial | Any stack |
+| [Fly.io](guides/fly-io.md) | Edge computing, Docker | None (pay-as-you-go) | Docker, Go, multi-region |
+| [Netlify](guides/netlify.md) | JAMstack, forms | 300 credits/mo | Static, serverless, forms |
 | [Cloudflare Pages](guides/cloudflare-pages.md) | Edge-first, full-stack | Unlimited bandwidth | Static, D1, KV, Workers |
-| [AWS ECS](guides/aws-ecs.md) | Production containers | 12-month free tier | Enterprise, Fargate |
+| [AWS ECS](guides/aws-ecs.md) | Production containers | $100-$200 credits (6 months) | Enterprise, Fargate |
 | [AWS Amplify](guides/aws-amplify.md) | Full-stack serverless | 1000 build min/mo | CI/CD, preview environments |
-| [DigitalOcean](guides/digitalocean.md) | VPS + App Platform | $200 credit | Self-hosted, full control |
+| [DigitalOcean](guides/digitalocean.md) | VPS + App Platform | $200 credit (60 days) | Self-hosted, full control |
+| [Coolify](guides/coolify.md) | Self-hosted PaaS | Free (bring your own server) | Push-to-deploy on any VPS |
+| [Hetzner](guides/hetzner.md) | VPS (EU pricing) | None (from ~EUR 6/mo) | Docker Compose, full control |
 
 ## Frameworks
 
@@ -29,10 +31,16 @@ Whether you're deploying a React app, a FastAPI backend, or a full-stack MERN pr
 |-----------|--------|---------------------|
 | [React (Vite)](frameworks/react-vite.md) | SPA deployment | GitHub Pages / Vercel |
 | [Next.js](frameworks/nextjs.md) | SSR / SSG / ISR | Vercel |
+| [Astro](frameworks/astro.md) | Static + server output | GitHub Pages / Netlify / Vercel |
+| [SvelteKit](frameworks/sveltekit.md) | Adapter-based SSR / static | Vercel / Cloudflare |
+| [Angular](frameworks/angular.md) | SPA + SSR deployment | GitHub Pages / Vercel |
 | [Express.js](frameworks/express.md) | Node.js backend | Render / Railway |
 | [FastAPI](frameworks/fastapi.md) | Python backend | Render / Railway |
 | [Flask](frameworks/flask.md) | Python backend | Render / Railway |
 | [Django](frameworks/django.md) | Python full-stack | Render / Railway |
+| [NestJS](frameworks/nestjs.md) | Node.js backend (TypeScript) | Render / Railway |
+| [Ruby on Rails](frameworks/rails.md) | Ruby full-stack | Render / Railway |
+| [Go (Gin)](frameworks/go-gin.md) | Go backend | Railway / Render |
 | [MERN Stack](frameworks/mern.md) | Full-stack (Mongo + Express + React + Node) | Render + GitHub Pages |
 | [FARM Stack](frameworks/farm.md) | Full-stack (FastAPI + React + MongoDB) | Render + GitHub Pages |
 
@@ -41,9 +49,11 @@ Whether you're deploying a React app, a FastAPI backend, or a full-stack MERN pr
 | Database | Guide | Type | Free Tier |
 |----------|-------|------|-----------|
 | [MongoDB Atlas](guides/mongodb-atlas.md) | Cloud MongoDB | Document (NoSQL) | 512 MB |
-| [Neon](guides/neon.md) | Serverless PostgreSQL | Relational | 0.5 GB + 191 compute hrs |
+| [Neon](guides/neon.md) | Serverless PostgreSQL | Relational | 0.5 GB + 100 CU-hrs per project |
 | [Supabase](guides/supabase.md) | Postgres + Auth + Storage + Realtime | BaaS | 500 MB + 50K MAU |
-| [Upstash](guides/upstash.md) | Serverless Redis + QStash | Cache / Queue | 10K commands/day |
+| [Upstash](guides/upstash.md) | Serverless Redis + QStash | Cache / Queue | 500K commands/mo |
+| [Turso](guides/turso.md) | Edge SQLite (libSQL) | Relational (SQLite) | 100 DBs + 5 GB |
+| [CockroachDB](guides/cockroachdb.md) | Distributed SQL (Postgres-compatible) | Relational | $15/mo credit (10 GiB + 50M RUs) |
 
 ## Reference Guides
 
@@ -53,6 +63,7 @@ Whether you're deploying a React app, a FastAPI backend, or a full-stack MERN pr
 | [DNS & Custom Domains](guides/dns-domains.md) | A records, CNAME, SSL/HTTPS for every platform |
 | [Environment Variables](guides/environment-variables.md) | Best practices, platform setup, build-time vs runtime |
 | [CI/CD Templates](guides/ci-cd-templates.md) | 7 copy-paste GitHub Actions workflows |
+| [Monitoring & Logging](guides/monitoring.md) | Free-tier uptime, logs, error tracking, cron alerting |
 
 ---
 
@@ -64,14 +75,15 @@ What are you deploying?
 +-- Static site / SPA (React, Vue, Astro)
 |   +-- Need custom domain? --------> GitHub Pages (free forever)
 |   +-- Need serverless functions? --> Vercel or Netlify
-|   +-- Need edge performance? ------> Cloudflare Pages
+|   +-- Need edge performance? ------> Cloudflare Workers (Pages still works)
 |   +-- Just want it live fast? -----> Vercel (zero config)
 |
 +-- Backend API (Express, FastAPI, Flask, Django)
 |   +-- Free is priority? -----------> Render (sleeps after 15 min)
-|   +-- Need always-on? ------------> Railway ($5/mo) or Fly.io
+|   +-- Need always-on? ------------> Railway ($5/mo) or Fly.io (pay-as-you-go)
 |   +-- Production scale? -----------> AWS ECS or DigitalOcean
 |   +-- Need Docker? ----------------> Fly.io or Railway
+|   +-- Own server / no fees? -------> Coolify on Hetzner
 |
 +-- Full-stack (frontend + backend + database)
 |   +-- MERN/FARM? -----------------> Render (backend) + GitHub Pages (frontend)
@@ -84,34 +96,41 @@ What are you deploying?
 |   +-- MongoDB --------------------> MongoDB Atlas (free 512 MB)
 |   +-- Postgres + Auth + Storage --> Supabase (free BaaS)
 |   +-- Redis / Caching ------------> Upstash (serverless, free)
+|   +-- SQLite at the edge ---------> Turso (free 100 DBs)
 |
 +-- Not sure? Check the Cost Comparison below
 ```
 
 ## Cost Comparison
 
+*Prices last verified: 2026-07-06.*
+
 ### Hosting Platforms
 
 | Platform | Free Tier | Cheapest Paid | Always-On | Custom Domain | Docker |
 |----------|-----------|---------------|-----------|---------------|--------|
-| GitHub Pages | Unlimited | N/A | Yes | Yes (free SSL) | No |
-| Vercel | Hobby (free) | Pro ($20/mo) | Yes | Yes | No |
+| GitHub Pages | 1 GB site, 100 GB/mo (soft) | N/A | Yes | Yes (free SSL) | No |
+| Vercel | Hobby: 100 GB transfer, 1M invocations, 4 active-CPU hrs/mo | Pro ($20/user/mo) | Yes | Yes | No |
 | Render | 750 hrs/mo | Starter ($7/mo) | Paid only | Yes | Yes |
-| Railway | $5 credit | Usage-based | Yes | Yes | Yes |
-| Fly.io | 3 shared VMs | ~$2-5/mo | Yes | Yes | Yes |
-| Netlify | 100 GB/mo | Pro ($19/mo) | Yes | Yes | No |
-| Cloudflare Pages | Unlimited | $20/mo (Workers Paid) | Yes | Yes | No |
-| DigitalOcean | $200 credit | $5/mo | Yes | Yes | Yes |
-| AWS ECS | 12-month free | ~$30-50/mo | Yes | Yes | Yes |
+| Railway | One-time $5 trial, then $1/mo credit | Hobby ($5/mo) | Yes (while credits last) | Yes | Yes |
+| Fly.io | None (pay-as-you-go, card required) | ~$2/mo (shared-cpu-1x 256MB) | Yes | Yes | Yes |
+| Netlify | 300 credits/mo (~15 GB bandwidth) | Personal ($9/mo) | Yes (until credits run out) | Yes | No |
+| Cloudflare Pages | Unlimited bandwidth, 500 builds/mo | $5/mo (Workers Paid) | Yes | Yes | No |
+| DigitalOcean | 3 static-site apps + $200/60-day credit | $4/mo (droplet), $5/mo (container) | Yes | Yes | Yes |
+| AWS ECS | $100-$200 credits, 6-month Free plan | ~$48/mo (2 Fargate tasks + ALB) | Yes | Yes | Yes |
+| Coolify | Free self-hosted (bring a VPS) | Coolify Cloud ($5/mo) | Yes | Yes | Yes |
+| Hetzner | None | ~EUR 6/mo (CX23 + IPv4) | Yes | Yes | Yes |
 
 ### Databases
 
 | Database | Free Tier | Cheapest Paid | Type |
 |----------|-----------|---------------|------|
-| MongoDB Atlas | 512 MB (M0) | M2 ($9/mo) | Document |
-| Neon | 0.5 GB + 191 hrs | Launch ($19/mo) | PostgreSQL |
+| MongoDB Atlas | 512 MB (Free cluster, M0) | Flex ($8-$30/mo, usage-capped) | Document |
+| Neon | 0.5 GB + 100 CU-hrs per project | Launch (pay-as-you-go, $0.106/CU-hr) | PostgreSQL |
 | Supabase | 500 MB + 50K MAU | Pro ($25/mo) | PostgreSQL + BaaS |
-| Upstash | 10K cmd/day | Pay-as-you-go | Redis |
+| Upstash | 500K cmd/mo | Pay-as-you-go ($0.20/100K cmds) | Redis |
+| Turso | 100 DBs + 5 GB | Developer ($4.99/mo) | SQLite (libSQL) |
+| CockroachDB | $15/mo credit (10 GiB + 50M RUs) | Usage beyond free credit | Distributed SQL |
 
 ## Guide Structure
 

--- a/frameworks/angular.md
+++ b/frameworks/angular.md
@@ -1,0 +1,427 @@
+# Deploy Angular
+
+> Deploy an Angular 22 app to GitHub Pages, Vercel, Netlify, or Cloudflare Pages, with a detour for SSR and hybrid rendering.
+
+Angular has a built-in deploy hook: `ng deploy` runs whatever deployment builder you added via `ng add`, and the CLI docs list official builders for GitHub Pages, Netlify, Firebase, and S3 (Vercel uses its own `vercel init angular` flow instead). This guide covers the four platforms that make sense on a free tier, plus the three things that trip up every first Angular deploy: the `dist/<project>/browser` output folder, the `--base-href` flag, and the SPA fallback for deep links. Current versions as of 2026-07-06: Angular 22 (released 2026-06-03), `@angular/cli` 22.0.5. Angular v22 requires Node.js `^22.22.3 || ^24.15.0 || ^26.0.0` and TypeScript `>=6.0.0 <6.1.0`; v20 and v21 are in LTS (v20 LTS ends 2026-11-28).
+
+## Prerequisites
+
+- [ ] [Node.js 22.22.3+](https://nodejs.org/) installed (Angular v22 also accepts Node 24.15+ or 26)
+- [ ] [Git](https://git-scm.com/downloads) installed
+- [ ] A [GitHub account](https://github.com/signup)
+- [ ] An account on your target platform: [Vercel](https://vercel.com/signup), [Netlify](https://app.netlify.com/signup), or [Cloudflare](https://dash.cloudflare.com/sign-up)
+
+---
+
+## Create the App
+
+```bash
+npm install -g @angular/cli
+ng new my-app
+cd my-app
+ng serve
+```
+
+`ng new` walks you through stylesheet and SSR prompts -- answer No to SSR for the static deploys below (Options A-D), or see [SSR and Hybrid Rendering](#ssr-and-hybrid-rendering). Open `http://localhost:4200` to confirm it works.
+
+Two build facts you need before deploying anywhere:
+
+1. `ng build` applies the **production configuration by default** -- AOT, minification, bundling, dead code elimination. No `--prod` flag, no extra config.
+2. With the default application builder, client bundles land in `dist/my-app/browser`, **not** `dist/my-app`. SSR server code (if any) goes to `dist/my-app/server`. Most platform "output directory" fields need the `browser` path.
+
+If a platform can't handle the nested folder, flatten it in `angular.json` with the object form of `outputPath`:
+
+```json
+"options": {
+  "outputPath": {
+    "base": "dist/my-app",
+    "browser": ""
+  }
+}
+```
+
+Push to GitHub before deploying:
+
+```bash
+git init -b main
+git add .
+git commit -m "Initial commit"
+git remote add origin https://github.com/<username>/my-app.git
+git push -u origin main
+```
+
+---
+
+## Option A: GitHub Pages (angular-cli-ghpages)
+
+[angular-cli-ghpages](https://github.com/angular-schule/angular-cli-ghpages) is the official `ng deploy` builder for GitHub Pages. Current version 3.1.0 (released 2026-06-08) supports Angular 18 through 22; older Angular versions need v1/v2 of the tool.
+
+### Step 1: Add the Deploy Builder
+
+```bash
+ng add angular-cli-ghpages
+```
+
+### Step 2: Deploy with the Correct base-href
+
+Project pages serve from `https://<username>.github.io/<repositoryname>/`, so the app must know its subpath. Pass it at deploy time -- leading and trailing slash both required:
+
+```bash
+ng deploy --base-href=/<repositoryname>/
+```
+
+This builds the app, injects the `<base href>`, and pushes the output to the `gh-pages` branch. Your app is live at `https://<username>.github.io/<repositoryname>/`.
+
+Skipping `--base-href` is the number one cause of a blank page on GitHub Pages -- see [Troubleshooting](#troubleshooting).
+
+### Step 3: Know What the Tool Did for You
+
+By default, angular-cli-ghpages creates two extra files in the deployed output:
+
+- **`404.html`** -- a copy of `index.html`. GitHub Pages serves this for any unknown path, which is the only known workaround for SPA routing on GitHub Pages. Disable with `--no-notfound` (you must, when targeting Cloudflare Pages -- see Option D).
+- **`.nojekyll`** -- disables Jekyll processing so underscore-prefixed asset files are served.
+
+One inherent limitation (angular-cli-ghpages issue #178, wontfix): deep links return an initial 404 network response before `404.html` loads the app. That is GitHub Pages static hosting behavior, not a bug in the tool.
+
+Useful flags: `--dir` (override the dist folder), `--branch` (default `gh-pages`), `--no-build` (deploy an existing build).
+
+### Deploying from CI (GitHub Actions)
+
+For non-interactive deploys, pass the repo and git identity explicitly and supply a token:
+
+```yaml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx ng deploy --base-href=/<repositoryname>/ --name="github-actions" --email=actions@users.noreply.github.com
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+```
+
+The tool reads `GH_TOKEN`, `PERSONAL_TOKEN`, or `GITHUB_TOKEN`. Gotcha: in GitHub Actions, the built-in `GITHUB_TOKEN` only triggers a Pages release on **private** repos. Public repos need a personal access token in `GH_TOKEN` (add it under **Settings** > **Secrets and variables** > **Actions**).
+
+You can also deploy to another repo entirely:
+
+```bash
+ng deploy --repo=https://github.com/<username>/<repositoryname>.git --name="Your Git Username" --email=your.mail@example.org
+```
+
+---
+
+## Option B: Vercel
+
+Vercel has a first-party Angular preset (detected via `@angular/cli` in your dependencies): build command `ng build`, dev command `ng serve --port $PORT`, output directory `dist`. It auto-descends -- if `dist` contains a single subdirectory it uses it, and if that contains a `browser/` subfolder it serves from there. So the Angular 17+ `dist/my-app/browser` layout works with zero configuration, no `vercel.json` needed.
+
+### Step 1: Import in Vercel
+
+1. Go to [vercel.com/new](https://vercel.com/new)
+2. Click **Import Git Repository** and select `my-app`
+3. Vercel detects Angular -- leave all build settings as-is
+4. Click **Deploy**
+
+Your app is live at `https://my-app.vercel.app`. No `--base-href` needed -- Vercel serves from the domain root.
+
+### Alternative: Deploy via CLI
+
+```bash
+npm i -g vercel
+cd my-app
+vercel          # First deploy: links project
+vercel --prod   # Deploy to production
+```
+
+Angular's own docs list `vercel init angular` as the Vercel path (it scaffolds a fresh Angular project pre-wired for Vercel), but importing an existing repo is the more common flow.
+
+Vercel serves `index.html` for SPA deep links out of the box with the Angular preset, and you get preview deployments on every PR plus automatic production deploys on push to `main`.
+
+---
+
+## Option C: Netlify
+
+Netlify auto-detects Angular and configures the publish directory from `angular.json`. The only manual step for a client-side-routed (non-SSR) app is the SPA redirect.
+
+### Step 1: Add the SPA Redirect
+
+Without it, deep links like `/about` return Netlify's 404 page on refresh. Two equivalent options -- pick one.
+
+**Option 1: `_redirects` file.** Create `src/_redirects`:
+
+```
+/* /index.html 200
+```
+
+Then include it in the build assets in `angular.json` (add to the existing `assets` array of the build target):
+
+```json
+"assets": [
+  "src/_redirects"
+]
+```
+
+**Option 2: `netlify.toml`** in the repo root:
+
+```toml
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+```
+
+### Step 2: Import in Netlify
+
+1. Go to [app.netlify.com](https://app.netlify.com/)
+2. **Add new site** > **Import an existing project**
+3. Select your GitHub repo -- Netlify fills in the Angular build settings
+4. Click **Deploy**
+
+There is also an official `ng deploy` builder if you prefer deploying from the CLI:
+
+```bash
+ng add @netlify-builder/deploy
+ng deploy
+```
+
+**SSR note:** if your app uses `@angular/ssr`, Netlify auto-configures it as an Edge Function -- and SSR pages **ignore** `_redirects`/`netlify.toml` redirects entirely (Edge Functions run first). Use Angular's own routing redirects instead, and test locally with `netlify serve`. Bonus: `NgOptimizedImage` automatically uses the Netlify Image CDN.
+
+---
+
+## Option D: Cloudflare Pages
+
+### New Project: One Command
+
+```bash
+npm create cloudflare@latest -- my-angular-app --framework=angular --platform=pages
+```
+
+This scaffolds an Angular project pre-configured for Pages. Build command is `npm run build`; the output directory is `dist/cloudflare` or `dist/cloudflare/browser` depending on Angular version.
+
+### Existing Project: Git Integration
+
+1. In the Cloudflare dashboard, go to **Workers & Pages** > **Create** > **Pages** > **Connect to Git**
+2. Select your repo
+3. Set build command `npm run build` and output directory `dist/my-app/browser` (the application builder's default output path)
+4. Deploy
+
+### SPA Fallback on Cloudflare
+
+Cloudflare Pages only activates SPA mode **when no `404.html` exists** in the output. This inverts the GitHub Pages rule:
+
+- Plain `ng build` output: fine as-is -- no `404.html` is emitted, deep links fall back to `index.html`.
+- Deploying with angular-cli-ghpages (it supports Cloudflare Pages too): you **must** pass `--no-notfound`, or the tool's default `404.html` copy disables SPA mode and every deep link renders the 404 page.
+
+```bash
+ng deploy --no-notfound   # when targeting Cloudflare Pages via angular-cli-ghpages
+```
+
+---
+
+## SSR and Hybrid Rendering
+
+Everything above deploys a client-rendered SPA. Angular also does server-side rendering and per-route hybrid rendering via `@angular/ssr`:
+
+```bash
+ng new my-app --ssr        # new project
+ng add @angular/ssr        # existing project
+```
+
+Hybrid rendering lets each route pick its mode -- `RenderMode.Server` (SSR), `RenderMode.Client` (CSR), or `RenderMode.Prerender` (SSG) -- declared in `app.routes.server.ts`:
+
+```ts
+// app.routes.server.ts
+import { RenderMode, ServerRoute } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  { path: '', renderMode: RenderMode.Prerender },
+  { path: 'dashboard', renderMode: RenderMode.Client },
+  { path: '**', renderMode: RenderMode.Server }
+];
+```
+
+and registered via `provideServerRendering(withRoutes(serverRoutes))` in `app.config.server.ts`.
+
+Where it deploys depends on the output mode:
+
+- **Default SSR build** prerenders the entire application and generates a server file (in `dist/my-app/server`). That server needs a Node host -- see the [Render guide](../guides/render.md) for a free-tier Node deployment. On Netlify, SSR is auto-configured as an Edge Function (Option C notes apply). Vercel's Angular preset handles the build too.
+- **`"outputMode": "static"`** in `angular.json` build options emits prerendered HTML only, no Node server required. The result deploys to any static platform in Options A-D.
+
+Skip classic Firebase Hosting for this: its framework-aware Angular support is stuck in early preview and "new participation in the Hosting frameworks experiment has been closed permanently." Google now points Angular SSR users at Firebase App Hosting instead.
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `GH_TOKEN` | Personal access token for angular-cli-ghpages CI deploys (required for Pages releases on public repos) | `ghp_xxxx` |
+| `PERSONAL_TOKEN` | Alternative token variable angular-cli-ghpages reads | `ghp_xxxx` |
+| `GITHUB_TOKEN` | Actions-provided token; only triggers a Pages release on private repos | provided by Actions |
+
+Those are deploy-time variables for CI. Inside the app itself, the story is different: **a static Angular build has no runtime environment variables.** There is no `import.meta.env`, no `process.env` in the browser, and no `NG_APP_` prefix magic in the default builder. Changing a dashboard env var on Vercel or Netlify does nothing to an already-built Angular bundle.
+
+The Angular pattern is build-time file replacement. Values live in environment files:
+
+```ts
+// src/environments/environment.ts
+export const environment = {
+  apiUrl: 'https://api.example.com'
+};
+```
+
+```ts
+import { environment } from '../environments/environment';
+
+fetch(`${environment.apiUrl}/todos`);
+```
+
+`ng generate environments` scaffolds the files, and `fileReplacements` in an `angular.json` configuration swaps one file for another per build config:
+
+```json
+"fileReplacements": [
+  {
+    "replace": "src/environments/environment.ts",
+    "with": "src/environments/environment.staging.ts"
+  }
+]
+```
+
+Then `ng build --configuration staging` bakes the staging values in. Need a different value? Rebuild. Never put secrets in environment files -- they ship to every browser.
+
+For local development against a backend, skip CORS entirely with the dev-server proxy. Create `src/proxy.conf.json`:
+
+```json
+{
+  "/api/**": {
+    "target": "http://localhost:3000"
+  }
+}
+```
+
+Wire it via the `proxyConfig` option on the `serve` target in `angular.json`, and restart `ng serve` after changes. Note the default `@angular/build:dev-server` uses Vite-style path matching; only the legacy builder uses Webpack-style.
+
+---
+
+## Custom Domain
+
+Domain setup is platform work, not Angular work. Follow the platform guide:
+
+- **GitHub Pages:** [GitHub Pages guide](../guides/github-pages.md#custom-domain). One Angular-specific step: with a custom domain the site serves from the root, so drop `--base-href` (or set it back to `/`) and redeploy.
+- **Vercel:** [Vercel guide](../guides/vercel.md) -- add the domain under **Settings** > **Domains**, create the DNS records the dashboard shows, SSL is automatic.
+- **Netlify:** [Netlify guide](../guides/netlify.md) -- **Domain settings** > add domain, then DNS.
+- **Cloudflare Pages:** [Cloudflare Pages guide](../guides/cloudflare-pages.md) -- custom domains attach in the project's **Custom domains** tab.
+
+---
+
+## Free Tier Info
+
+| Platform | Plan | Exact limits |
+|----------|------|--------------|
+| GitHub Pages | Free, $0 | Published site max 1 GB, soft bandwidth limit 100 GB/month, soft limit 10 builds/hour (does not apply to custom Actions workflows) |
+| Vercel | Hobby, $0 | 1M function invocations/month, 4 CPU-hrs active CPU, 360 GB-hrs provisioned memory, up to 1M edge requests, 200 projects, 100 deployments/day, 50 domains per project, 300s max function duration, non-commercial personal use only. Pro is $20 per user/month |
+| Netlify | Free, $0 | 300 credits/month, hard limit, no auto-recharge. 1 GB bandwidth = 20 credits (~15 GB/month), 10,000 web requests = 2 credits, 1 production deploy = 15 credits, 1 GB-hr functions compute = 10 credits. Personal $9/month = 1,000 credits |
+| Cloudflare Pages | Free, $0 | See the [Cloudflare Pages guide](../guides/cloudflare-pages.md) for current plan limits |
+
+For a plain client-rendered Angular app, GitHub Pages costs nothing and needs no account beyond GitHub. If you expect real traffic or want preview deploys, Vercel or Cloudflare Pages are the better defaults.
+
+---
+
+## Troubleshooting
+
+### Problem: Blank page after deploying to GitHub Pages
+
+**Cause:** The `<base href>` still points at `/`, so every script and stylesheet resolves to `https://<username>.github.io/main.js` instead of `https://<username>.github.io/<repositoryname>/main.js`.
+
+**Fix:** Deploy with the base href set to your repo name, leading and trailing slash included:
+
+```bash
+ng deploy --base-href=/<repositoryname>/
+```
+
+Building manually instead? The same flag exists on the build: `ng build --base-href=/<repositoryname>/`. (`ng build` also supports `--deploy-url` for asset URLs, but the docs note `<base href>` is generally preferred.)
+
+### Problem: Deep links 404 on refresh
+
+**Cause:** Angular routing is client-side. For routed SPAs the Angular docs require the server to return `index.html` for unknown paths, and static hosts don't do that by default.
+
+**Fix:** Platform-specific fallback:
+
+- **GitHub Pages:** the `404.html` copy angular-cli-ghpages creates by default is the workaround. Don't pass `--no-notfound` here. Deep links still log an initial 404 network response before the app loads -- inherent to GitHub Pages, not fixable.
+- **Netlify:** add the `/* /index.html 200` redirect (Option C, Step 1).
+- **Cloudflare Pages:** make sure no `404.html` exists in the output -- SPA mode only activates without one.
+- **Vercel:** handled by the Angular preset; no action needed.
+
+### Problem: Build fails with a bundle budget error
+
+**Cause:** The production bundle exceeded `maximumError` in the size budgets under `configurations.production.budgets` in `angular.json`. The default `initial` budget warns at 250kb and errors at 500kb; `anyComponentStyle` warns at 2kb and errors at 4kb. `maximumWarning` only warns; `maximumError` fails the build.
+
+**Fix:** First find out what got heavy:
+
+```bash
+ng build --stats-json
+```
+
+Analyze the emitted stats file with [esbuild-visualizer](https://www.npmjs.com/package/esbuild-visualizer). Lazy-load heavy routes and trim oversized dependencies. If the size is genuinely justified, raise the budget in `angular.json`:
+
+```json
+"budgets": [
+  {
+    "type": "initial",
+    "maximumWarning": "500kb",
+    "maximumError": "1mb"
+  }
+]
+```
+
+Budget types available: `initial`, `anyComponentStyle`, `bundle`, `all`, `allScript`, `any`, plus relative budgets via a baseline and percentages.
+
+### Problem: Cloudflare Pages shows the 404 page for every route
+
+**Cause:** A `404.html` file in the deployed output. Cloudflare Pages only activates SPA mode when no `404.html` exists, and angular-cli-ghpages creates one by default.
+
+**Fix:** Redeploy without it:
+
+```bash
+ng deploy --no-notfound
+```
+
+### Problem: GitHub Actions deploy runs green but the public Pages site never updates
+
+**Cause:** The workflow authenticated with the built-in `GITHUB_TOKEN`, which only triggers a Pages release on private repos.
+
+**Fix:** Create a personal access token, store it as a repo secret, and pass it as `GH_TOKEN`:
+
+```yaml
+- run: npx ng deploy --base-href=/<repositoryname>/ --name="github-actions" --email=actions@users.noreply.github.com
+  env:
+    GH_TOKEN: ${{ secrets.GH_TOKEN }}
+```
+
+### Problem: Platform deploys but serves a directory listing or "index.html not found"
+
+**Cause:** The output directory setting points at `dist/my-app`, but the application builder writes client files to `dist/my-app/browser`.
+
+**Fix:** Point the platform at the `browser` subfolder (e.g. output directory `dist/my-app/browser` on Cloudflare Pages), or flatten the output in `angular.json`:
+
+```json
+"outputPath": {
+  "base": "dist/my-app",
+  "browser": ""
+}
+```
+
+Vercel needs neither -- its Angular preset auto-descends into single subdirectories and `browser/` folders.

--- a/frameworks/astro.md
+++ b/frameworks/astro.md
@@ -1,0 +1,534 @@
+# Deploy Astro
+
+> Deploy an Astro site to GitHub Pages, Netlify, Vercel, Cloudflare Workers, or your own Node server.
+
+This guide covers deploying Astro 7 in both output modes: **static** (prerendered HTML, host anywhere) and **server** (on-demand rendering through an adapter). Pick the platform section that matches your host -- each one works standalone.
+
+## Prerequisites
+
+- [ ] [Node.js 22.12+](https://nodejs.org/) installed (Astro 7 requires Node >=22.12.0)
+- [ ] [Git](https://git-scm.com/downloads) installed
+- [ ] A [GitHub account](https://github.com/signup)
+- [ ] (Per platform) A [Netlify](https://app.netlify.com/signup), [Vercel](https://vercel.com/signup), or [Cloudflare](https://dash.cloudflare.com/sign-up) account
+
+---
+
+## Create the App
+
+```bash
+npm create astro@latest my-astro-app
+cd my-astro-app
+npm run dev
+```
+
+Open `http://localhost:4321` (Astro's default dev port; override with `--port` or `server.port`).
+
+Already on an older Astro? Upgrade with:
+
+```bash
+npx @astrojs/upgrade
+```
+
+Astro 7 (current: 7.0.6) ships a stricter Rust-based compiler -- invalid or unclosed HTML that previously slipped through now **fails the build**. It also upgrades to Vite 8, removes `@astrojs/db`, and reserves the filename `src/fetch.ts` for advanced routing. Fix compiler errors locally before pushing, or your first deploy will fail.
+
+---
+
+## Pick an Output Mode
+
+Astro has exactly two output modes. There is no `'hybrid'` mode anymore -- hybrid rendering is done per page.
+
+| Mode | Config | What it means |
+|------|--------|---------------|
+| Static (default) | `output: 'static'` | Entire site prerendered to HTML at build time |
+| Server | `output: 'server'` | All pages rendered on demand per request |
+
+Mix them per page with the `prerender` export:
+
+```js
+// In a .astro page's frontmatter (or a .js/.ts endpoint)
+
+// Static site, but THIS page renders on demand:
+export const prerender = false;
+
+// Server site, but THIS page is prerendered at build time:
+export const prerender = true;
+```
+
+### Adapters
+
+Any on-demand rendering (including a single `prerender = false` page) **requires an adapter** matching your host:
+
+```bash
+npx astro add netlify      # @astrojs/netlify
+npx astro add vercel       # @astrojs/vercel
+npx astro add cloudflare   # @astrojs/cloudflare
+npx astro add node         # @astrojs/node (self-host)
+```
+
+Each command installs the package and updates `astro.config.mjs` for you. Fully static sites need no adapter.
+
+### Server Islands
+
+Server islands let a static page defer one dynamic component to render after page load. Add `server:defer` to any server-rendered component and give it placeholder UI via the `fallback` slot:
+
+```astro
+---
+import Recommendations from '../components/Recommendations.astro';
+---
+<Recommendations server:defer>
+  <div slot="fallback">Loading recommendations...</div>
+</Recommendations>
+```
+
+Rules that bite in production:
+
+- Requires an adapter. Does not work on fully static sites (so not on GitHub Pages).
+- Props are passed via an encrypted query string capped at **2048 bytes**. Larger props fall back to a POST request and skip the browser cache.
+- For rolling or multi-region deploys, all instances must share the encryption key. Generate one and set it as an env var:
+
+```bash
+npx astro create-key
+# Set the output as ASTRO_KEY on your host
+```
+
+### Config Essentials
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  site: 'https://example.com',  // Final deployed URL. Unset by default; needed for sitemaps and canonical URLs
+  base: '/docs',                // Only if deploying under a subpath
+  trailingSlash: 'ignore',      // Default. Also: 'always' | 'never'
+});
+```
+
+---
+
+## Option A: GitHub Pages (Static Only)
+
+GitHub Pages hosts static output for free. No adapter, no server islands.
+
+### Step 1: Set `site` and `base`
+
+Edit `astro.config.mjs`:
+
+```js
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  site: 'https://<username>.github.io',
+  base: '/my-astro-app',  // Must match your repo name
+});
+```
+
+Skip `base` only if the repo is the special `<username>.github.io` repo. With a `base` set, prefix **all internal links** with it:
+
+```astro
+<a href="/my-astro-app/about">About</a>
+```
+
+### Step 2: Push to GitHub
+
+```bash
+git init -b main
+git add astro.config.mjs package.json package-lock.json src public tsconfig.json
+git commit -m "Initial commit"
+git remote add origin https://github.com/<username>/my-astro-app.git
+git push -u origin main
+```
+
+### Step 3: Add the Official Deploy Workflow
+
+Astro maintains its own action, [withastro/action](https://github.com/withastro/action) (current release v6.1.1, 2026-04-20). Create `.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: withastro/action@v6
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5
+```
+
+The action auto-detects your package manager from the lockfile (npm, yarn, pnpm, bun, or deno) and caches `node_modules/.astro` by default. Optional inputs if the defaults don't fit:
+
+| Input | Default | Purpose |
+|-------|---------|---------|
+| `path` | repo root | Astro project location in a monorepo |
+| `node-version` | `24` | Node version for the build |
+| `package-manager` | auto-detected | Force a specific PM |
+| `build-cmd` | PM's build script | Custom build command |
+| `cache` | `true` | Toggle build caching |
+| `cache-dir` | `node_modules/.astro` | Cache location |
+| `out-dir` | `dist` | Build output directory |
+
+### Step 4: Enable Pages
+
+1. Repo **Settings** > **Pages**
+2. Under **Source**, select **GitHub Actions**
+3. Push -- the workflow builds and deploys
+
+Your site is live at `https://<username>.github.io/my-astro-app`.
+
+---
+
+## Option B: Netlify
+
+Netlify handles both static and SSR Astro. Requires Node v22.12.0+ at build time -- pin it:
+
+```bash
+echo "22.12.0" > .nvmrc
+```
+
+### Step 1: Add Config (and Adapter for SSR)
+
+Create `netlify.toml`:
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "dist"
+```
+
+Static sites stop here. For SSR:
+
+```bash
+npx astro add netlify
+```
+
+This installs `@astrojs/netlify` (current: 8.1.1) and wires the adapter into `astro.config.mjs`. Astro middleware runs on Netlify Edge Functions.
+
+### Step 2: Deploy
+
+**Dashboard:** push to GitHub, then in Netlify click **Add a new site** > **Import an existing project** and select the repo.
+
+**CLI:**
+
+```bash
+npm install --global netlify-cli
+netlify login
+netlify init
+```
+
+`netlify init` links the repo and sets up continuous deployment -- every push to `main` builds and deploys.
+
+---
+
+## Option C: Vercel
+
+### Step 1: Adapter (SSR Only)
+
+Static sites deploy with zero config -- Vercel auto-detects the Astro preset. For SSR:
+
+```bash
+npx astro add vercel
+```
+
+This installs `@astrojs/vercel` (current: 11.0.2). Useful adapter options:
+
+```js
+import { defineConfig } from 'astro/config';
+import vercel from '@astrojs/vercel';
+
+export default defineConfig({
+  output: 'server',
+  adapter: vercel({
+    webAnalytics: { enabled: true },
+    maxDuration: 60,  // seconds, per function
+    isr: {
+      expiration: 60 * 60 * 24,          // revalidate cached pages daily
+      bypassToken: process.env.ISR_TOKEN, // on-demand revalidation
+      exclude: ['/preview', /^\/api\/.+/],
+    },
+  }),
+});
+```
+
+The adapter can also route images through Vercel's Image Optimization API via `imageService`.
+
+### Step 2: Deploy
+
+**Dashboard:** push to GitHub, import at [vercel.com/new](https://vercel.com/new). Vercel detects Astro automatically -- click **Deploy**.
+
+**CLI:**
+
+```bash
+npm install -g vercel
+vercel
+# Answer N when asked to override settings -- the Astro preset is correct
+```
+
+---
+
+## Option D: Cloudflare Workers
+
+Since v13, `@astrojs/cloudflare` deploys to **Cloudflare Workers only** -- it no longer supports Cloudflare Pages. Current adapter version: 14.1.1.
+
+### Step 1: Add the Adapter and Wrangler
+
+```bash
+npx astro add cloudflare
+npm install wrangler@latest --save-dev
+```
+
+A `wrangler.jsonc` is optional for basic projects -- Astro generates sane defaults, including `"main": "@astrojs/cloudflare/entrypoints/server"`. If you do write one:
+
+```jsonc
+// wrangler.jsonc -- SSR site
+{
+  "name": "my-astro-app",
+  "main": "dist/_worker.js/index.js",
+  "compatibility_date": "2026-07-06",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": { "directory": "./dist" }
+}
+```
+
+Static-only sites drop `main` and `compatibility_flags` and keep just `"assets": { "directory": "./dist" }`.
+
+With the adapter installed, `astro dev` runs in workerd -- Cloudflare's actual production runtime -- so dev matches production. Sessions auto-provision a Workers KV binding named `SESSION`, and `imageService` defaults to `'cloudflare-binding'`.
+
+### Step 2: Preview and Deploy
+
+```bash
+# Local preview on workerd
+npx astro build && npx wrangler dev
+
+# Deploy
+npx astro build && npx wrangler deploy
+```
+
+Per-environment builds: `CLOUDFLARE_ENV=staging astro build`.
+
+**Git integration (Workers Builds):** in the dashboard go to **Compute** > **Workers & Pages** > **Create application** > **Import a repository**, set build command `npx astro build` and deploy command `npx wrangler deploy`, then **Save and Deploy**.
+
+---
+
+## Option E: Node Server (Self-Host)
+
+Run Astro SSR on any box with Node 22 -- a VPS, a container, or a PaaS.
+
+### Step 1: Add the Node Adapter
+
+```bash
+npx astro add node
+```
+
+This installs `@astrojs/node` (current: 11.0.2):
+
+```js
+import { defineConfig } from 'astro/config';
+import node from '@astrojs/node';
+
+export default defineConfig({
+  output: 'server',
+  adapter: node({ mode: 'standalone' }),
+});
+```
+
+Use `mode: 'middleware'` instead to mount the built handler inside an existing Express or Fastify app.
+
+### Step 2: Build and Run
+
+```bash
+npm run build
+node ./dist/server/entry.mjs
+```
+
+Override the bind address and port with env vars:
+
+```bash
+HOST=0.0.0.0 PORT=4321 node ./dist/server/entry.mjs
+```
+
+The default request body size limit is 1 GB. Point your process manager (systemd, pm2, Docker CMD) at `dist/server/entry.mjs` and you're done.
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `PUBLIC_API_URL` | Exposed to the client (any `PUBLIC_`-prefixed var) | `https://api.example.com` |
+| `API_SECRET` | Server-only (no prefix = never shipped to the browser) | `sk-...` |
+| `ASTRO_KEY` | Stable server-island encryption key for rolling/multi-region deploys | output of `npx astro create-key` |
+
+Access rules:
+
+- In Astro code, use `import.meta.env.PUBLIC_API_URL` -- **not** `process.env`.
+- In `astro.config.mjs`, use `process.env`.
+- On Cloudflare (and Deno), the adapter provides its own runtime env access instead of `process.env`.
+
+For type-safe env vars, declare a schema with `astro:env`:
+
+```js
+// astro.config.mjs
+import { defineConfig, envField } from 'astro/config';
+
+export default defineConfig({
+  env: {
+    schema: {
+      PUBLIC_API_URL: envField.string({ context: 'client', access: 'public' }),
+      API_SECRET: envField.string({ context: 'server', access: 'secret' }),
+    },
+  },
+});
+```
+
+Undeclared runtime secrets can be read server-side with `getSecret()` from `astro:env/server`.
+
+Where to set them per platform:
+
+- **GitHub Pages:** repo **Settings** > **Secrets and variables** > **Actions**, then pass into the build step's `env:` block. Static builds bake values in at build time.
+- **Netlify:** **Site configuration** > **Environment variables**.
+- **Vercel:** project **Settings** > **Environment Variables**.
+- **Cloudflare:** **Settings** > **Variables and Secrets** on the Worker, or `[vars]` in `wrangler.jsonc`.
+- **Node:** export in the shell, systemd unit, or Docker env.
+
+---
+
+## Custom Domain
+
+### GitHub Pages
+
+1. Create `public/CNAME` containing exactly your domain:
+
+```
+www.example.com
+```
+
+2. Update `astro.config.mjs`: set `site` to the custom domain and **remove `base`** (then strip the base prefix from internal links):
+
+```js
+export default defineConfig({
+  site: 'https://www.example.com',
+});
+```
+
+3. Configure DNS:
+
+| Type | Name | Value |
+|------|------|-------|
+| A | @ | `185.199.108.153` |
+| A | @ | `185.199.109.153` |
+| A | @ | `185.199.110.153` |
+| A | @ | `185.199.111.153` |
+| AAAA | @ | `2606:50c0:8000::153` (through `:8003::153`) |
+| CNAME | www | `<username>.github.io` |
+
+4. Repo **Settings** > **Pages** > **Custom domain**, enter the domain, **Save**, then tick **Enforce HTTPS** (can take up to 24h to become available).
+
+### Netlify / Vercel / Cloudflare
+
+Add the domain in the project dashboard (Domain settings), point DNS at the exact values the dashboard shows for your project, and SSL is provisioned automatically.
+
+---
+
+## Free Tier Info
+
+| Platform | Price | What you get | Watch out for |
+|----------|-------|--------------|---------------|
+| GitHub Pages | Free | 1 GB published site, 100 GB/month bandwidth (soft), 10 builds/hour (soft) | Static only; the builds/hour limit does not apply to custom Actions workflows like withastro/action |
+| Cloudflare Workers | Free | 100,000 requests/day, 10 ms CPU per invocation; static asset requests free and unlimited | Paid plan starts at $5 USD/month minimum per account |
+| Netlify | Free (credit-based) | 300 credits/month hard cap. Costs: 20 credits/GB bandwidth, 15 credits per production deploy, 10 credits per GB-hour compute, 2 credits per 10,000 requests. Deploy previews, branch deploys, and form submissions cost 0 credits | Sites pause when credits run out and Free accounts cannot buy more; next tier is Personal at $9/month (1,000 credits) |
+| Vercel Hobby | Free | 1M edge requests, 1M function invocations, 4 active-CPU hours, 360 GB-hrs provisioned memory, 5,000 image transformations, 100 deployments/day per month; function max duration 300s | Non-commercial personal use only; exceeding a limit pauses that feature for up to 30 days; Pro is $20 per user/month |
+
+For a mostly-static Astro site, GitHub Pages or Cloudflare (static assets free and unlimited) are the safest free homes. For SSR, Cloudflare's 100k requests/day is the most generous hard number.
+
+---
+
+## Troubleshooting
+
+### Problem: Build fails with "Cannot use server-rendered pages without an adapter"
+
+**Cause:** A page opted into on-demand rendering (`output: 'server'` or `export const prerender = false`) but no adapter is installed. The full error: "Cannot use server-rendered pages without an adapter. Please install and configure the appropriate server adapter for your final deployment."
+
+**Fix:** Install the adapter matching your host:
+
+```bash
+npx astro add netlify   # or vercel / cloudflare / node
+```
+
+### Problem: "getStaticPaths() function is required for dynamic routes"
+
+**Cause:** A dynamic route like `src/pages/blog/[slug].astro` is being built in static mode without telling Astro which paths exist.
+
+**Fix:** Export `getStaticPaths()` returning all paths:
+
+```astro
+---
+export async function getStaticPaths() {
+  return [
+    { params: { slug: 'first-post' } },
+    { params: { slug: 'second-post' } },
+  ];
+}
+---
+```
+
+Or switch that page to on-demand rendering (`export const prerender = false` plus an adapter).
+
+### Problem: React/Vue/Svelte component renders but is not interactive
+
+**Cause:** Astro ships zero JavaScript by default -- framework components are rendered to static HTML unless you hydrate them.
+
+**Fix:** Add a `client:*` directive:
+
+```astro
+<Counter client:load />
+```
+
+### Problem: "window is not defined" or "document is not defined"
+
+**Cause:** Browser-only APIs running during the server render.
+
+**Fix:** Move the code into a `<script>` tag or a framework lifecycle hook (`useEffect`, `onMounted`, `onMount`) and hydrate the component with a `client:*` directive.
+
+### Problem: Cloudflare build fails resolving `node:` imports
+
+**Cause:** Node built-ins on Workers require the compatibility flag, and full built-in Node.js API support also requires a recent compatibility date.
+
+**Fix:** In `wrangler.jsonc` set both:
+
+```jsonc
+{
+  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_date": "2024-09-23"  // or later
+}
+```
+
+### Problem: "Cannot find package X" after adding an integration
+
+**Cause:** Missing peer dependencies -- `astro add` installs the integration but some package managers skip peers.
+
+**Fix:** Install them manually:
+
+```bash
+npm install @astrojs/react react react-dom
+```
+
+Yarn 2+ (Berry) additionally needs `nodeLinker: "node-modules"` in `.yarnrc.yml`. In monorepos, you may need to add Astro packages to `vite.ssr.noExternal`.

--- a/frameworks/django.md
+++ b/frameworks/django.md
@@ -6,7 +6,7 @@ This guide covers deploying a production-ready Django application to Render's fr
 
 ## Prerequisites
 
-- [ ] [Python 3.9+](https://www.python.org/downloads/) installed
+- [ ] [Python 3.12+](https://www.python.org/downloads/) installed
 - [ ] [Git](https://git-scm.com/downloads) installed
 - [ ] A [GitHub account](https://github.com/signup)
 - [ ] A [Render account](https://render.com/) (sign up with GitHub)
@@ -19,7 +19,14 @@ This guide covers deploying a production-ready Django application to Render's fr
 mkdir my-django-app && cd my-django-app
 python -m venv venv
 source venv/bin/activate   # Windows: venv\Scripts\activate
-pip install django gunicorn whitenoise dj-database-url psycopg2-binary python-dotenv
+pip install django gunicorn whitenoise dj-database-url "psycopg[binary]" python-dotenv
+```
+
+Or with [uv](https://docs.astral.sh/uv/) (faster drop-in for venv + pip):
+
+```bash
+uv venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
+uv pip install django gunicorn whitenoise dj-database-url "psycopg[binary]" python-dotenv
 ```
 
 Create the Django project:
@@ -157,7 +164,6 @@ if not DEBUG:
     SECURE_SSL_REDIRECT = True
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
-    SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
     CSRF_TRUSTED_ORIGINS = [
         f"https://{host.strip()}" for host in ALLOWED_HOSTS if host.strip()
@@ -264,13 +270,15 @@ pip freeze > requirements.txt
 Or manually create a minimal `requirements.txt`:
 
 ```
-django==5.1
-gunicorn==23.0.0
-whitenoise==6.8.2
-dj-database-url==2.3.0
-psycopg2-binary==2.9.10
-python-dotenv==1.0.1
+django==6.0.6
+gunicorn==26.0.0
+whitenoise==6.12.0
+dj-database-url==3.1.2
+psycopg[binary]==3.3.4
+python-dotenv==1.2.2
 ```
+
+Django 6.0 requires Python 3.12+. If you need the LTS line instead, pin `django==5.2.15` (Django 5.2 LTS, supported to April 2028, runs on Python 3.10-3.14). Django recommends psycopg 3 (`psycopg[binary]`); psycopg2 support is likely to be deprecated in a future release.
 
 Create `build.sh` (Render build script):
 
@@ -310,12 +318,14 @@ services:
           name: django-db
           property: connectionString
       - key: PYTHON_VERSION
-        value: "3.12.0"
+        value: "3.14.3"
 
 databases:
   - name: django-db
     plan: free
 ```
+
+Note: Render's free Postgres databases expire 30 days after creation (1 GB storage). For anything long-lived, use a paid plan (from $6/month) or a free [Neon](../guides/neon.md) database.
 
 Create `.gitignore`:
 
@@ -363,6 +373,8 @@ git push -u origin main
    - **Plan:** Free
 4. Copy the **Internal Database URL** (starts with `postgresql://`)
 
+Warning: free Render Postgres databases expire 30 days after creation and your app loses its database. Upgrade to a paid plan (Basic-256mb, $6/month) before the expiry, or use Option B for a free database that does not expire.
+
 ### Option B: Neon PostgreSQL
 
 Follow the [Neon guide](../guides/neon.md) to create a free PostgreSQL database and copy the connection string.
@@ -402,7 +414,7 @@ curl https://my-django-app.onrender.com/api/items/
 | `DEBUG` | Set to `False` in production | `False` |
 | `ALLOWED_HOSTS` | Comma-separated allowed hostnames | `my-django-app.onrender.com` |
 | `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@host/db` |
-| `PYTHON_VERSION` | Python version for Render | `3.12.0` |
+| `PYTHON_VERSION` | Python version for Render (fully qualified) | `3.14.3` |
 
 ### Set on Render
 
@@ -443,35 +455,28 @@ Render provisions a free SSL certificate automatically once DNS propagates.
 
 ## Alternative Platforms
 
-### Vercel (with django-vercel adapter)
+### Vercel (zero-config)
 
-Vercel supports Django via serverless functions. Install the adapter:
+Vercel has zero-config Django support: it detects `manage.py`, resolves the entrypoint from `WSGI_APPLICATION`/`ASGI_APPLICATION` in your settings, runs `collectstatic` automatically when `STATIC_ROOT` is set (serving static files from the CDN), and deploys the app as a single Vercel Function on Fluid compute. No adapter package and no `builds`/`routes` config are needed -- just import the repo at [vercel.com](https://vercel.com/).
 
-```bash
-pip install django-vercel
-```
-
-Create `vercel.json`:
+Optional per-function config goes in `vercel.json` under `functions`, keyed by the entrypoint file:
 
 ```json
 {
-  "builds": [
-    { "src": "config/wsgi.py", "use": "@vercel/python" }
-  ],
-  "routes": [
-    { "src": "/(.*)", "dest": "config/wsgi.py" }
-  ]
+  "functions": {
+    "config/wsgi.py": { "maxDuration": 60 }
+  }
 }
 ```
 
-Note: Vercel's serverless model works best for lightweight APIs. For full Django with admin, background tasks, or long-running requests, Render or Railway is a better fit.
+Note: the whole app runs as one Function, so Function limitations apply (500 MB standard bundle limit, no long-running background tasks). For Django with persistent workers or scheduled jobs, Render or Railway is a better fit.
 
 ### Railway
 
 1. Install the Railway CLI: `npm install -g @railway/cli`
 2. Login: `railway login`
 3. Initialize: `railway init`
-4. Add PostgreSQL: `railway add --plugin postgresql`
+4. Add PostgreSQL: `railway add --database postgres`
 5. Deploy: `railway up`
 
 Railway auto-detects Django projects and configures the build. Set `ALLOWED_HOSTS` and `SECRET_KEY` in the Railway dashboard.
@@ -587,3 +592,5 @@ If your Django project is in a subdirectory, adjust the Render **Root Directory*
 1. This is expected on the free tier (30-60 second cold start)
 2. Add the `/health/` endpoint for external uptime monitoring
 3. Upgrade to Starter ($7/month) for always-on
+
+Note: free web services also share 750 instance hours per workspace per month; when exhausted, all free services are suspended until the next month.

--- a/frameworks/express.md
+++ b/frameworks/express.md
@@ -6,7 +6,7 @@ This guide walks through deploying a production-ready Express.js application to 
 
 ## Prerequisites
 
-- [ ] [Node.js 18+](https://nodejs.org/) installed
+- [ ] [Node.js 22+](https://nodejs.org/) installed (24 LTS recommended; 18 and 20 are end-of-life)
 - [ ] [Git](https://git-scm.com/downloads) installed
 - [ ] A [GitHub account](https://github.com/signup)
 - [ ] A [Render account](https://render.com/) (sign up with GitHub)
@@ -19,6 +19,7 @@ This guide walks through deploying a production-ready Express.js application to 
 mkdir my-express-api && cd my-express-api
 npm init -y
 npm install express cors dotenv
+# or with pnpm (v11, needs Node 22.13+): pnpm init && pnpm add express cors dotenv
 ```
 
 Create `server.js`:
@@ -74,8 +75,8 @@ Update `package.json`:
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "dotenv": "^16.3.0",
-    "express": "^4.18.0"
+    "dotenv": "^17.4.2",
+    "express": "^5.2.1"
   }
 }
 ```
@@ -116,7 +117,7 @@ git push -u origin main
 3. Connect your GitHub repository
 4. Configure:
    - **Name:** `my-express-api`
-   - **Runtime:** Node
+   - **Language:** Node
    - **Build Command:** `npm install`
    - **Start Command:** `npm start`
    - **Instance Type:** Free
@@ -141,7 +142,10 @@ import mongoose from 'mongoose';
 
 mongoose.connect(process.env.MONGODB_URI, { dbName: 'myapp' })
   .then(() => console.log('Connected to MongoDB'))
-  .catch(err => console.error('MongoDB connection error:', err));
+  .catch(err => {
+    console.error('MongoDB connection error:', err);
+    process.exit(1); // exit so the platform restarts the service instead of serving 500s
+  });
 
 const itemSchema = new mongoose.Schema({
   name: { type: String, required: true },
@@ -180,7 +184,7 @@ const { Pool } = pg;
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  ssl: { rejectUnauthorized: false },
+  ssl: { require: true },
 });
 
 app.get('/api/items', async (req, res) => {
@@ -217,8 +221,8 @@ Set `DATABASE_URL` in Render's Environment tab. See the [Neon guide](../guides/n
 
 1. Go to your service on Render
 2. Click the **Environment** tab
-3. Add each variable
-4. Click **Save Changes** (triggers redeploy)
+3. Click **+ Add Environment Variable** and add each variable
+4. Save with **Save, rebuild, and deploy** or **Save and deploy** (choose **Save only** to skip the redeploy)
 
 ### Use CORS_ORIGIN for Dynamic CORS
 
@@ -266,15 +270,17 @@ git add package.json package-lock.json
 git push
 ```
 
-To pin the Node.js version, add to `package.json`:
+To pin the Node.js version, set a `NODE_VERSION` env var on Render, add a `.node-version` or `.nvmrc` file, or add a bounded range to `package.json`:
 
 ```json
 {
   "engines": {
-    "node": ">=18.0.0"
+    "node": "22.x"
   }
 }
 ```
+
+Always include an upper bound -- an unbounded range like `>=22` resolves to the latest Node release (Render's default is currently 24.x), which can change under you.
 
 ### Problem: "No open ports detected"
 
@@ -303,6 +309,8 @@ app.use(cors({
 }));
 ```
 
+Tip: for local development with a Vite frontend, you can skip CORS entirely by proxying in `vite.config.ts` (`server: { proxy: { '/api': 'http://localhost:3000' } }`) and calling relative `/api/*` paths.
+
 ### Problem: Request body is undefined
 
 **Cause:** Missing `express.json()` middleware.
@@ -316,11 +324,11 @@ app.use(express.urlencoded({ extended: true }));  // For form data
 
 ### Problem: Free tier cold start is too slow
 
-**Cause:** Render's free tier spins down after 15 minutes of inactivity.
+**Cause:** Render's free tier spins down after 15 minutes without inbound traffic. Note the free tier also caps each workspace at 750 instance hours per month, so keeping one service pinged awake full-time uses nearly all of it.
 
 **Fix:**
 
-1. Add a `/health` endpoint and monitor it with an external pinger for demos
+1. Add a `/health` endpoint and ping it on a schedule for demos (an external pinger or a GitHub Actions cron workflow that curls it)
 2. Or upgrade to Starter ($7/month) for always-on
 3. Optimize startup time: defer database connections, reduce dependency count
 

--- a/frameworks/farm.md
+++ b/frameworks/farm.md
@@ -6,8 +6,8 @@ This guide covers deploying a complete FARM stack application: a React + Vite fr
 
 ## Prerequisites
 
-- [ ] [Python 3.9+](https://www.python.org/downloads/) installed
-- [ ] [Node.js 18+](https://nodejs.org/) installed
+- [ ] [Python 3.12+](https://www.python.org/downloads/) installed
+- [ ] [Node.js 22+](https://nodejs.org/) installed
 - [ ] [Git](https://git-scm.com/downloads) installed
 - [ ] A [GitHub account](https://github.com/signup)
 - [ ] A [Render account](https://render.com/) (sign up with GitHub)
@@ -21,11 +21,13 @@ This guide covers deploying a complete FARM stack application: a React + Vite fr
 GitHub Pages (Frontend)          Render (Backend)             MongoDB Atlas (Database)
 +------------------+            +------------------+          +------------------+
 |  React + Vite    | -- API --> |  FastAPI          | ------> |  MongoDB         |
-|  Static SPA      |   calls   |  async + Motor    |         |  Cloud database  |
-|  Axios HTTP      |            |  Pydantic models  |         |  Free M0 tier    |
+|  Static SPA      |   calls   |  async + PyMongo  |         |  Cloud database  |
+|  Axios HTTP      |            |  Pydantic models  |         |  Free tier (M0)  |
 +------------------+            +------------------+          +------------------+
      VITE_API_URL                   MONGODB_URI
 ```
+
+> **Alternative:** You can collapse frontend and backend into a single service by building the React app into the backend tree and having FastAPI serve it: `app.mount("/", StaticFiles(directory="client_build", html=True), name="frontend")`, with API routes under an `/api` prefix so they do not collide. One URL, no CORS in production, and it fits in a single free-tier Render service.
 
 ---
 
@@ -33,7 +35,7 @@ GitHub Pages (Frontend)          Render (Backend)             MongoDB Atlas (Dat
 
 Follow the [MongoDB Atlas guide](../guides/mongodb-atlas.md) to:
 
-1. Create a free M0 cluster
+1. Create a Free cluster (the free tier, formerly M0)
 2. Create a database user
 3. Whitelist all IPs (`0.0.0.0/0`) for Render access
 4. Copy your connection string
@@ -55,13 +57,23 @@ mkdir farm-app && cd farm-app
 mkdir server && cd server
 python -m venv venv
 source venv/bin/activate   # Windows: venv\Scripts\activate
-pip install fastapi uvicorn[standard] motor pydantic-settings python-dotenv
+pip install fastapi uvicorn[standard] pymongo pydantic-settings python-dotenv
 ```
+
+Or with [uv](https://docs.astral.sh/uv/) (faster, replaces venv + pip):
+
+```bash
+uv venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+uv pip install fastapi uvicorn[standard] pymongo pydantic-settings python-dotenv
+```
+
+> **Note:** Earlier FARM tutorials used [Motor](https://pypi.org/project/motor/) as the async MongoDB driver. Motor is officially deprecated as of 2026-05-14 (critical fixes only until 2027-05-14); MongoDB recommends the PyMongo Async API (`AsyncMongoClient` in the `pymongo` package), which this guide uses.
 
 ### Create server/config.py
 
 ```python
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -69,8 +81,7 @@ class Settings(BaseSettings):
     database_name: str = "farm_app"
     cors_origin: str = "http://localhost:5173"
 
-    class Config:
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 
 settings = Settings()
@@ -79,10 +90,10 @@ settings = Settings()
 ### Create server/database.py
 
 ```python
-from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import AsyncMongoClient
 from config import settings
 
-client = AsyncIOMotorClient(settings.mongodb_uri)
+client = AsyncMongoClient(settings.mongodb_uri)
 db = client[settings.database_name]
 
 # Collections
@@ -121,7 +132,7 @@ class ItemResponse(BaseModel):
 
 ```python
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from bson import ObjectId
@@ -148,7 +159,7 @@ def item_to_response(item: dict) -> dict:
         "name": item["name"],
         "description": item.get("description", ""),
         "category": item.get("category", "general"),
-        "created_at": item.get("created_at", datetime.utcnow()),
+        "created_at": item.get("created_at", datetime.now(timezone.utc)),
     }
 
 
@@ -184,7 +195,7 @@ async def create_item(data: ItemCreate):
         "name": data.name,
         "description": data.description,
         "category": data.category,
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(timezone.utc),
     }
     result = await items_collection.insert_one(doc)
     doc["_id"] = result.inserted_id
@@ -221,11 +232,11 @@ async def delete_item(item_id: str):
 ### Create server/requirements.txt
 
 ```
-fastapi==0.115.0
-uvicorn[standard]==0.32.0
-motor==3.6.0
-pydantic-settings==2.6.0
-python-dotenv==1.0.1
+fastapi==0.139.0
+uvicorn[standard]==0.50.1
+pymongo==4.17.0
+pydantic-settings==2.14.2
+python-dotenv==1.2.2
 ```
 
 ### Create server/.env (for local development)
@@ -276,7 +287,7 @@ git push -u origin main
 3. Connect the `farm-server` repository
 4. Configure:
    - **Name:** `farm-server`
-   - **Runtime:** Python
+   - **Language:** Python 3
    - **Build Command:** `pip install -r requirements.txt`
    - **Start Command:** `uvicorn main:app --host 0.0.0.0 --port $PORT`
    - **Instance Type:** Free
@@ -307,6 +318,8 @@ cd client
 npm install
 npm install axios
 ```
+
+Or with [pnpm](https://pnpm.io/): `pnpm create vite client --template react`, then `pnpm install` and `pnpm add axios`.
 
 ### Create client/src/api.js
 
@@ -423,7 +436,7 @@ function App() {
                 <strong>{item.name}</strong>
                 {item.description && (
                   <span style={{ color: '#666', marginLeft: '0.5rem' }}>
-                    — {item.description}
+                    -- {item.description}
                   </span>
                 )}
               </div>
@@ -467,6 +480,8 @@ cd client && npm run dev
 
 Open http://localhost:5173 to verify the frontend talks to the backend.
 
+> **Tip:** For local development you can skip CORS entirely by adding a dev proxy to `vite.config.js` and calling relative `/api` paths: `server: { proxy: { '/api': { target: 'http://localhost:8000', changeOrigin: true } } }`. Production builds still use `VITE_API_URL`, which Vite bakes in at build time.
+
 ---
 
 ## Step 5: Deploy the Frontend to GitHub Pages
@@ -507,11 +522,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci
@@ -519,7 +534,7 @@ jobs:
         env:
           VITE_API_URL: https://farm-server.onrender.com
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -531,7 +546,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
 
 ### Enable GitHub Pages
@@ -574,15 +589,18 @@ Now that the frontend is deployed, update `CORS_ORIGIN` on Render:
 Create `docker-compose.yml` in the project root (`farm-app/`):
 
 ```yaml
-version: "3.9"
-
 services:
   mongodb:
-    image: mongo:7
+    image: mongo:8
     ports:
       - "27017:27017"
     volumes:
       - mongo_data:/data/db
+    healthcheck:
+      test: mongosh --eval "db.adminCommand('ping')" --quiet
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   server:
     build: ./server
@@ -593,7 +611,8 @@ services:
       - DATABASE_NAME=farm_app
       - CORS_ORIGIN=http://localhost:5173
     depends_on:
-      - mongodb
+      mongodb:
+        condition: service_healthy
     volumes:
       - ./server:/app
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
@@ -616,7 +635,7 @@ volumes:
 Create `server/Dockerfile`:
 
 ```dockerfile
-FROM python:3.12-slim
+FROM python:3.13-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -627,7 +646,7 @@ CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
 Create `client/Dockerfile`:
 
 ```dockerfile
-FROM node:20-slim
+FROM node:22-slim
 WORKDIR /app
 COPY package*.json .
 RUN npm ci

--- a/frameworks/fastapi.md
+++ b/frameworks/fastapi.md
@@ -6,7 +6,7 @@ This guide covers deploying a production-ready FastAPI application to Render's f
 
 ## Prerequisites
 
-- [ ] [Python 3.9+](https://www.python.org/downloads/) installed
+- [ ] [Python 3.13+](https://www.python.org/downloads/) installed (FastAPI and uvicorn require 3.10 minimum; 3.9 is EOL)
 - [ ] [Git](https://git-scm.com/downloads) installed
 - [ ] A [GitHub account](https://github.com/signup)
 - [ ] A [Render account](https://render.com/) (sign up with GitHub)
@@ -19,7 +19,9 @@ This guide covers deploying a production-ready FastAPI application to Render's f
 mkdir my-fastapi-app && cd my-fastapi-app
 python -m venv venv
 source venv/bin/activate   # Windows: venv\Scripts\activate
-pip install fastapi uvicorn[standard] python-dotenv
+pip install "fastapi[standard]" python-dotenv
+# fastapi[standard] bundles uvicorn and the fastapi CLI
+# or with uv: uv venv && uv pip install "fastapi[standard]" python-dotenv
 ```
 
 Create `main.py`:
@@ -69,10 +71,12 @@ pip freeze > requirements.txt
 Or manually create a minimal `requirements.txt`:
 
 ```
-fastapi==0.109.0
-uvicorn[standard]==0.27.0
-python-dotenv==1.0.0
+fastapi==0.139.0
+uvicorn[standard]==0.50.1
+python-dotenv==1.2.2
 ```
+
+Both fastapi and uvicorn now require Python 3.10+.
 
 Create `.gitignore`:
 
@@ -86,7 +90,8 @@ __pycache__/
 Test locally:
 
 ```bash
-uvicorn main:app --reload
+fastapi dev main.py
+# or: uvicorn main:app --reload
 # Open http://localhost:8000
 # API docs at http://localhost:8000/docs
 ```
@@ -113,11 +118,13 @@ git push -u origin main
 3. Connect your GitHub repository
 4. Configure:
    - **Name:** `my-fastapi-app`
-   - **Runtime:** Python
+   - **Language:** Python 3
    - **Build Command:** `pip install -r requirements.txt`
    - **Start Command:** `uvicorn main:app --host 0.0.0.0 --port $PORT`
    - **Instance Type:** Free
 5. Click **Create Web Service**
+
+To pin the Python version, add a `.python-version` file (e.g. `3.13`) to the repo root -- Render reads it to select the build image instead of using its default.
 
 Your API is live at `https://my-fastapi-app.onrender.com`. The interactive docs are at `/docs`.
 
@@ -128,9 +135,11 @@ Your API is live at `https://my-fastapi-app.onrender.com`. The interactive docs 
 ### Option A: Neon PostgreSQL + SQLAlchemy
 
 ```bash
-pip install sqlalchemy psycopg2-binary
+pip install sqlalchemy "psycopg[binary]"
 pip freeze > requirements.txt
 ```
+
+Psycopg 3 is the current driver for new projects (psycopg2 is maintenance-only). Use the `postgresql+psycopg://` URL scheme so SQLAlchemy picks it up.
 
 Create `database.py`:
 
@@ -157,15 +166,20 @@ Create `models.py`:
 
 ```python
 from sqlalchemy import Column, Integer, String, DateTime
-from datetime import datetime
+from datetime import datetime, timezone
 from database import Base
 
 class Item(Base):
     __tablename__ = "items"
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(255), nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
 ```
+
+`datetime.utcnow()` is deprecated since Python 3.12; use timezone-aware `datetime.now(timezone.utc)` instead.
 
 Update `main.py`:
 
@@ -214,23 +228,25 @@ def create_item(data: dict, db: Session = Depends(get_db)):
 
 Set `DATABASE_URL` in Render's Environment tab. See the [Neon guide](../guides/neon.md) for setup.
 
-### Option B: MongoDB Atlas + Motor
+### Option B: MongoDB Atlas + PyMongo Async
 
 ```bash
-pip install motor
+pip install pymongo
 pip freeze > requirements.txt
 ```
+
+Motor is deprecated (2026-05-14); MongoDB recommends the PyMongo Async API, a near drop-in replacement for `AsyncIOMotorClient`.
 
 Update `main.py`:
 
 ```python
 import os
 from fastapi import FastAPI
-from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import AsyncMongoClient
 
 app = FastAPI()
 
-client = AsyncIOMotorClient(os.environ["MONGODB_URI"])
+client = AsyncMongoClient(os.environ["MONGODB_URI"])
 db = client["myapp"]
 
 @app.get("/api/items")
@@ -255,7 +271,7 @@ Set `MONGODB_URI` in Render's Environment tab. See the [MongoDB Atlas guide](../
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `PORT` | Server port (auto-set by Render) | `10000` |
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@host/db` |
+| `DATABASE_URL` | PostgreSQL connection string | `postgresql+psycopg://user:pass@host/db` |
 | `MONGODB_URI` | MongoDB connection string | `mongodb+srv://...` |
 | `SECRET_KEY` | App secret key | `your-secret-key-here` |
 | `CORS_ORIGIN` | Allowed frontend origin | `https://myapp.github.io` |
@@ -335,6 +351,8 @@ app.add_middleware(
 
 Or set `CORS_ORIGIN` as an environment variable on Render.
 
+Note: CORS headers are missing on unhandled 500 responses, so a browser "CORS error" often masks a server error. Check the Render logs before touching CORS config.
+
 ### Problem: 422 Unprocessable Entity on POST requests
 
 **Cause:** Request body doesn't match the expected format, or Content-Type header is missing.
@@ -366,7 +384,19 @@ def create_item(data: ItemCreate, db: Session = Depends(get_db)):
 **Fix:**
 
 1. This is expected on the free tier (30-60 second cold start)
-2. Add a `/health` endpoint for external monitoring
+2. Add a `/health` endpoint and keep the service warm with a scheduled GitHub Actions ping:
+
+```yaml
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl --silent --max-time 30 https://my-fastapi-app.onrender.com/health || echo "ignoring"
+```
+
 3. Upgrade to Starter ($7/month) for always-on
 
 ### Problem: "SSL connection is required" with Neon database
@@ -383,6 +413,8 @@ engine = create_engine(
     connect_args={"sslmode": "require"},
 )
 ```
+
+If you use Neon's pooled connection string, remove `channel_binding=require` from it -- PgBouncer does not support channel binding, and Neon's console includes that parameter by default.
 
 ### Problem: Import error with relative imports
 

--- a/frameworks/flask.md
+++ b/frameworks/flask.md
@@ -6,7 +6,7 @@ This guide covers deploying a production-ready Flask application to Render's fre
 
 ## Prerequisites
 
-- [ ] [Python 3.9+](https://www.python.org/downloads/) installed
+- [ ] [Python 3.10+](https://www.python.org/downloads/) installed (3.12 or 3.13 recommended; 3.9 is EOL and gunicorn 26 requires 3.10+)
 - [ ] [Git](https://git-scm.com/downloads) installed
 - [ ] A [GitHub account](https://github.com/signup)
 - [ ] A [Render account](https://render.com/) (sign up with GitHub)
@@ -20,6 +20,14 @@ mkdir my-flask-app && cd my-flask-app
 python -m venv venv
 source venv/bin/activate   # Windows: venv\Scripts\activate
 pip install flask gunicorn python-dotenv flask-cors
+```
+
+Or with [uv](https://docs.astral.sh/uv/), a faster drop-in alternative to venv and pip:
+
+```bash
+uv venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+uv pip install flask gunicorn python-dotenv flask-cors
 ```
 
 Create `app.py`:
@@ -78,8 +86,9 @@ __pycache__/
 .env
 instance/
 *.db
-migrations/
 ```
+
+Do not gitignore `migrations/` -- Flask-Migrate's migration scripts must be committed so `flask db upgrade` can run on Render during the build.
 
 Test locally:
 
@@ -211,8 +220,10 @@ Set `DATABASE_URL` in Render's Environment tab. See the [Neon guide](../guides/n
 Install dependencies:
 
 ```bash
-pip install pymongo[srv]
+pip install pymongo
 ```
+
+`mongodb+srv://` connection strings work out of the box -- dnspython is now a mandatory pymongo dependency, so the old `pymongo[srv]` extra is gone (installing it triggers a pip warning about an unknown extra).
 
 Create `app.py` with MongoDB:
 
@@ -360,14 +371,16 @@ pip freeze > requirements.txt
 Or manually create a minimal `requirements.txt` (SQLAlchemy version):
 
 ```
-flask==3.1.0
-gunicorn==23.0.0
-flask-cors==5.0.0
+flask==3.1.3
+gunicorn==26.0.0
+flask-cors==6.0.5
 flask-sqlalchemy==3.1.1
-flask-migrate==4.0.7
-psycopg2-binary==2.9.10
-python-dotenv==1.0.1
+flask-migrate==4.1.0
+psycopg2-binary==2.9.12
+python-dotenv==1.2.2
 ```
+
+Use flask-cors 6.x -- 5.0.0 ships known CVEs (CVE-2024-6839, CVE-2024-6844, CVE-2024-6866) that were fixed in 6.0.0. Note gunicorn 26 requires Python 3.10+.
 
 Create `build.sh`:
 
@@ -392,11 +405,13 @@ chmod +x build.sh
 Create `.env` (for local development only):
 
 ```bash
-FLASK_ENV=development
+FLASK_DEBUG=1
 SECRET_KEY=local-dev-secret-key
 DATABASE_URL=sqlite:///app.db
 CORS_ORIGIN=http://localhost:5173
 ```
+
+`FLASK_ENV` was removed in Flask 2.3 and does nothing on Flask 3.x. Use `FLASK_DEBUG=1` or `flask run --debug` for local debug mode; never set it in production.
 
 Test with Gunicorn locally:
 
@@ -427,7 +442,7 @@ git push -u origin main
 3. Connect your GitHub repository
 4. Configure:
    - **Name:** `my-flask-app`
-   - **Runtime:** Python
+   - **Language:** Python 3
    - **Build Command:** `./build.sh`
    - **Start Command:** `gunicorn app:app --bind 0.0.0.0:$PORT`
    - **Instance Type:** Free
@@ -450,13 +465,12 @@ curl https://my-flask-app.onrender.com/api/items
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `SECRET_KEY` | Flask secret key | `a3f8b2c1d4e5...` |
-| `FLASK_ENV` | Environment (`production` on Render) | `production` |
 | `DATABASE_URL` | PostgreSQL connection string (SQLAlchemy) | `postgresql://user:pass@host/db` |
 | `MONGODB_URI` | MongoDB connection string (PyMongo) | `mongodb+srv://...` |
 | `DATABASE_NAME` | MongoDB database name | `flask_app` |
 | `CORS_ORIGIN` | Allowed frontend origin | `https://myapp.github.io` |
 | `PORT` | Server port (auto-set by Render) | `10000` |
-| `PYTHON_VERSION` | Python version for Render | `3.12.0` |
+| `PYTHON_VERSION` | Python version for Render (fully qualified) | `3.13.5` |
 
 ### Set on Render
 
@@ -533,13 +547,13 @@ def public_route():
 
 ### Railway
 
-1. Install the Railway CLI: `npm install -g @railway/cli`
+1. Install the Railway CLI: `npm install -g @railway/cli` (or `curl -fsSL agents.railway.com | sh`)
 2. Login: `railway login`
 3. Initialize: `railway init`
-4. Add PostgreSQL: `railway add --plugin postgresql`
+4. Add PostgreSQL: `railway add --database postgres`
 5. Deploy: `railway up`
 
-Railway auto-detects Flask projects from `requirements.txt`. Set `SECRET_KEY` and other variables in the Railway dashboard. The start command defaults to `gunicorn app:app`.
+Railway auto-detects Flask projects from `requirements.txt`. Set `SECRET_KEY` and other variables in the Railway dashboard. Railway's Railpack builder generates a start command that references `main:app`, so for this guide's `app.py` layout set a custom start command in the service settings: `gunicorn app:app --bind 0.0.0.0:$PORT`.
 
 ### Fly.io
 
@@ -547,13 +561,7 @@ Railway auto-detects Flask projects from `requirements.txt`. Set `SECRET_KEY` an
 2. Login: `fly auth login`
 3. Launch: `fly launch`
 
-Fly.io generates a `fly.toml` configuration file. Create a `Procfile` for Fly:
-
-```
-web: gunicorn app:app --bind 0.0.0.0:8080
-```
-
-Or set the start command in `fly.toml`:
+`fly launch` generates a `fly.toml` configuration file and a Dockerfile that runs gunicorn (the old Procfile/buildpack flow is no longer the documented path). Adjust the start command in `fly.toml` if needed:
 
 ```toml
 [processes]
@@ -570,7 +578,7 @@ Deploy with:
 fly deploy
 ```
 
-Fly.io provides persistent volumes and built-in PostgreSQL. Set environment variables with `fly secrets set SECRET_KEY=your-key`.
+Fly.io provides persistent volumes and Managed Postgres (the old app-based "Fly Postgres" is unmanaged and unsupported; use Managed Postgres or an external provider like [Neon](../guides/neon.md)). Set environment variables with `fly secrets set SECRET_KEY=your-key`.
 
 ---
 
@@ -692,6 +700,12 @@ flask db upgrade
 
 If this is a fresh database, run `flask db upgrade` to apply all existing migrations.
 
+### Problem: First request after inactivity is very slow
+
+**Cause:** Render free web services spin down after 15 minutes without inbound traffic; the next request triggers a cold start. Each workspace also gets 750 free instance hours per calendar month (free services are suspended when exhausted).
+
+**Fix:** Expect cold starts on the free tier, or upgrade to a paid instance (Starter, $7/mo) which never spins down.
+
 ### Problem: App works locally but crashes on Render
 
 **Cause:** Missing environment variables, different Python version, or a dependency issue.
@@ -712,4 +726,4 @@ def not_found(error):
     return jsonify({"error": "Not found"}), 404
 ```
 
-4. To pin the Python version, set `PYTHON_VERSION` to `3.12.0` in Render's environment variables
+4. To pin the Python version, set `PYTHON_VERSION` to a fully qualified version (e.g. `3.13.5`) in Render's environment variables, or add a `.python-version` file at the repo root (may omit the patch, e.g. `3.13`). Render's default is Python 3.14.x for services created on or after 2026-02-11.

--- a/frameworks/go-gin.md
+++ b/frameworks/go-gin.md
@@ -1,0 +1,482 @@
+# Deploy Go (Gin)
+
+> Deploy a Gin API to Fly.io, Railway, or Render with a static binary, release mode, health checks, and graceful shutdown.
+
+This guide covers deploying a production-ready Gin application to three platforms: **Fly.io** (pay-as-you-go, no free tier for new accounts), **Railway** ($1/month free credit), and **Render** (free tier with spin-down). It includes release mode configuration, static binary builds, minimal Docker images, and the health check pattern every platform expects.
+
+## Prerequisites
+
+- [ ] [Go 1.25+](https://go.dev/dl/) installed (latest stable is 1.26.4; Gin's quickstart requires Go 1.25 or above)
+- [ ] [Git](https://git-scm.com/downloads) installed
+- [ ] A [GitHub account](https://github.com/signup) (for Railway and Render auto-deploys)
+- [ ] [Docker](https://docs.docker.com/get-started/get-docker/) installed (optional, for the container image in Step 4)
+- [ ] (For Fly.io) [flyctl](https://fly.io/docs/flyctl/install/) installed and a [Fly.io account](https://fly.io/) (credit card required)
+- [ ] (For Railway) A [Railway account](https://railway.com/)
+- [ ] (For Render) A [Render account](https://render.com/) (sign up with GitHub)
+
+---
+
+## Step 1: Create a Gin App
+
+```bash
+mkdir my-gin-api && cd my-gin-api
+go mod init github.com/<username>/my-gin-api
+go get -u github.com/gin-gonic/gin
+# installs Gin v1.12.0 (2026-02-28), which requires Go 1.24+
+```
+
+Create `main.go`:
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	router := gin.Default()
+
+	// Gin trusts ALL proxies by default -- the docs call this "NOT safe".
+	// Pass nil so ClientIP() returns the remote address directly,
+	// or list your proxy's IPs/CIDRs if you need the real client IP.
+	router.SetTrustedProxies(nil)
+
+	router.GET("/", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "API is running"})
+	})
+
+	// Health check -- Fly, Railway, and Render all probe this
+	router.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	// Every platform below injects PORT; bind 0.0.0.0, never 127.0.0.1
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	srv := &http.Server{
+		Addr:    ":" + port, // ":" prefix binds 0.0.0.0
+		Handler: router,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("listen: %s", err)
+		}
+	}()
+
+	// Graceful shutdown -- PaaS platforms send SIGTERM on deploy and spin-down
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+	log.Println("shutting down server...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatal("server forced to shutdown:", err)
+	}
+}
+```
+
+If you don't need graceful shutdown, `router.Run()` with no arguments binds `0.0.0.0:8080` and respects the `PORT` env var automatically. The explicit `http.Server` version above is what the Gin docs recommend for production.
+
+Test locally:
+
+```bash
+go run .
+# [GIN-debug] Listening and serving HTTP on :8080
+curl http://localhost:8080/health
+# {"status":"ok"}
+```
+
+---
+
+## Step 2: Switch to Release Mode
+
+In debug mode Gin prints this on every start:
+
+```
+[WARNING] Running in "debug" mode. Switch to "release" mode in production.
+ - using env:   export GIN_MODE=release
+ - using code:  gin.SetMode(gin.ReleaseMode)
+```
+
+Set release mode via the environment (preferred -- no code change between dev and prod):
+
+```bash
+export GIN_MODE=release   # Windows PowerShell: $env:GIN_MODE="release"
+go run .
+```
+
+Or programmatically, before creating the router:
+
+```go
+gin.SetMode(gin.ReleaseMode)
+```
+
+Valid `GIN_MODE` values are `debug`, `release`, and `test`. Production should always run `release`.
+
+---
+
+## Step 3: Build a Static Binary
+
+```bash
+CGO_ENABLED=0 go build -ldflags="-s -w" -o app .
+./app
+```
+
+What the flags do:
+
+- `CGO_ENABLED=0` produces a fully static binary with no libc dependency -- it runs in `scratch` and distroless images.
+- `-s` omits the symbol table and debug information (and implies `-w`).
+- `-w` omits the DWARF symbol table.
+
+Together they cut binary size significantly with no runtime cost.
+
+---
+
+## Step 4: Containerize (Distroless or Scratch)
+
+Multi-stage build: compile in the official `golang` image, ship only the binary. Create `Dockerfile`:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM golang:1.26 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /go/bin/app .
+
+# distroless/static (~2 MiB) ships ca-certificates, tzdata,
+# a root /etc/passwd entry, and /tmp -- everything scratch lacks
+FROM gcr.io/distroless/static-debian13:nonroot
+COPY --from=build /go/bin/app /
+ENV GIN_MODE=release
+EXPOSE 8080
+CMD ["/app"]
+```
+
+Build and run:
+
+```bash
+docker build -t my-gin-api .
+docker run -p 8080:8080 my-gin-api
+curl http://localhost:8080/health
+```
+
+Image choices:
+
+- **`gcr.io/distroless/static-debian13`** -- recommended for static Go binaries. The `:nonroot` tag runs as a non-root user.
+- **`FROM scratch`** -- an empty base image; smallest possible, but ships no CA bundle, so any outbound HTTPS call fails with `x509: certificate signed by unknown authority`. Use distroless unless your app makes zero outbound TLS calls.
+- **`gcr.io/distroless/base`** -- use only if you need cgo/libc (adds glibc and libssl).
+- **`golang:alpine`** as a builder is "highly experimental, and not officially supported by the Go project" due to musl libc. Stick with the default Debian-based tags (`1.26` = 1.26.4, also tagged `bookworm`/`trixie`).
+
+---
+
+## Step 5: Push to GitHub
+
+Railway and Render deploy from GitHub. Fly.io deploys from your local directory, so you can skip this for Fly-only setups (but push anyway).
+
+```bash
+git init
+git branch -M main
+cat > .gitignore <<'EOF'
+app
+*.exe
+.env
+EOF
+git add .gitignore go.mod go.sum main.go Dockerfile
+git commit -m "Initial commit"
+git remote add origin https://github.com/<username>/my-gin-api.git
+git push -u origin main
+```
+
+---
+
+## Option A: Deploy to Fly.io
+
+> **No free tier.** Fly.io no longer offers free plans to new customers. New organizations are pay-as-you-go, require a credit card, and are billed only for resources consumed. The cheapest machine (shared-cpu-1x, 256 MB RAM) costs $0.0028/hour, about $2.02/month running 24/7. A stopped machine's rootfs still costs $0.15 per GB per 30 days.
+
+### Step A1: Launch
+
+```bash
+fly launch
+# Detected a Go app
+```
+
+`fly launch` reads the Go version from `go.mod` and generates a multi-stage Debian bookworm Dockerfile with CGO enabled by default, plus a `fly.toml`. If you prefer the distroless image from Step 4, keep your own Dockerfile instead of the generated one.
+
+### Step A2: Configure fly.toml
+
+The default `internal_port` is 8080, which matches Gin's default. Add a health check:
+
+```toml
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    timeout = "5s"
+    path = "/health"
+```
+
+`auto_stop_machines = "stop"` plus `min_machines_running = 0` stops machines when idle so you only pay for actual usage (accepted values: `"off"`, `"stop"`, `"suspend"`).
+
+### Step A3: Deploy
+
+```bash
+fly deploy
+fly status      # machine states and health checks
+fly apps open   # opens https://my-gin-api.fly.dev
+```
+
+Secrets are runtime-only and never baked into the image:
+
+```bash
+fly secrets set DATABASE_URL="postgres://..."
+```
+
+If the build hangs, retry with `fly deploy --depot=false` or `fly deploy --local-only`. If you get a registry 401, run `fly auth logout` then `fly auth login`.
+
+---
+
+## Option B: Deploy to Railway
+
+### Step B1: Create the Service
+
+1. Go to [railway.com/new](https://railway.com/new)
+2. Choose **Deploy from GitHub repo** and select `my-gin-api`
+3. Railway's default builder, Railpack, detects Go from `go.mod` (or `go.work`, or a root `main.go`) and builds a static binary named `out` with `-ldflags="-w -s"` -- no build config needed
+
+Railpack resolves the Go version in this order: `mise.toml`/`.tool-versions`, then `go.mod`, then the `RAILPACK_GO_VERSION` env var, then default 1.23. Keep the `go` directive in `go.mod` current -- the 1.23 fallback is below Gin v1.12.0's minimum of Go 1.24.
+
+### Step B2: Add a Health Check (config-as-code)
+
+Create `railway.json` in the repo root:
+
+```json
+{
+  "build": {
+    "builder": "RAILPACK"
+  },
+  "deploy": {
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300
+  }
+}
+```
+
+The health check must return HTTP 200 on that path. Railway injects a `PORT` env var and probes the same port your app listens on -- the `os.Getenv("PORT")` in Step 1 handles this. Default timeout is 300 seconds (adjustable via `RAILWAY_HEALTHCHECK_TIMEOUT_SEC`).
+
+### Step B3: Get a Public URL
+
+1. Open the service **Settings** > **Networking** > **Public Networking**
+2. Click **Generate Domain** for a `.railway.app` URL
+
+Push to `main` to redeploy:
+
+```bash
+git add railway.json
+git commit -m "Add Railway health check config"
+git push
+```
+
+---
+
+## Option C: Deploy to Render
+
+### Step C1: Create the Web Service
+
+1. Go to [dashboard.render.com](https://dashboard.render.com/)
+2. Click **New** > **Web Service** and connect your GitHub repository
+3. Configure:
+   - **Name:** `my-gin-api`
+   - **Language:** Go (native runtime)
+   - **Build Command:** `go build -tags netgo -ldflags '-s -w' -o app`
+   - **Start Command:** `./app`
+   - **Instance Type:** Free
+4. Under **Advanced**, set **Health Check Path** to `/health`
+5. Click **Create Web Service**
+
+Your API is live at the assigned `https://my-gin-api.onrender.com` URL.
+
+### Step C2: Know the Runtime Rules
+
+- Render injects `PORT` (default `10000`) and requires binding to host `0.0.0.0` -- the deploy fails if Render cannot detect a bound port. The code from Step 1 satisfies both.
+- Ports 18012, 18013, and 19099 are reserved -- don't bind them.
+- The native Go runtime auto-updates to the latest stable Go 1.x (usually within 24 hours of release) and **cannot be pinned**, unlike Node or Python. To lock a Go version, deploy the Docker image from Step 4 instead (select **Docker** as the language).
+- Deploy timeouts: build command 120 minutes, pre-deploy 30 minutes, start command 15 minutes. If any command fails or times out, the entire deploy fails.
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `PORT` | Port to listen on (Railway injects it; Render defaults to `10000`; Fly routes to `internal_port`) | `8080` |
+| `GIN_MODE` | Gin mode: `debug`, `release`, or `test` | `release` |
+| `DATABASE_URL` | Database connection string (if you add one) | `postgres://user:pass@host/db` |
+
+### Set on Fly.io
+
+```bash
+fly secrets set GIN_MODE=release DATABASE_URL="postgres://..."
+```
+
+Secrets are runtime-only. Non-secret values like `GIN_MODE` can also live in the Dockerfile (`ENV GIN_MODE=release`, as in Step 4).
+
+### Set on Railway
+
+1. Open the service and click the **Variables** tab
+2. Add each variable and deploy
+
+### Set on Render
+
+1. Go to your service on Render
+2. Click the **Environment** tab
+3. Add each variable
+4. Click **Save Changes** (triggers redeploy)
+
+---
+
+## Custom Domain
+
+### Fly.io
+
+```bash
+fly certs add api.example.com
+# wildcard needs quotes: fly certs add "*.example.com"
+fly certs check api.example.com   # verify issuance
+fly certs setup api.example.com   # prints the DNS records to create
+```
+
+If the app has no public IPs yet, allocate them with `fly ips allocate`. For an apex domain, create A + AAAA records pointing at those IPs; for a subdomain, a CNAME to `my-gin-api.fly.dev` is enough.
+
+### Railway
+
+1. Service **Settings** > **Networking** > add a custom domain
+2. Add **both** the CNAME and TXT records Railway shows you at your DNS host -- the TXT record is required for verification
+
+### Render
+
+1. Service **Settings** > **Custom Domains** > **Add Custom Domain**, then click **Verify**
+2. Configure DNS:
+
+| Type | Name | Value |
+|------|------|-------|
+| A | `@` (apex) | `216.24.57.1` |
+| CNAME | `www` | `my-gin-api.onrender.com` |
+
+3. Remove any AAAA records -- Render does not support IPv6 for custom domains
+4. TLS certificates are issued and renewed automatically, with HTTP to HTTPS redirect
+
+---
+
+## Free Tier Info
+
+| Platform | Free tier | Exact limits |
+|----------|-----------|--------------|
+| Fly.io | **None** for new customers | Pay-as-you-go, credit card required. shared-cpu-1x 256 MB: $0.0028/hr (~$2.02/mo); stopped machine rootfs: $0.15/GB per 30 days. Legacy free allowances only apply to pre-2024-10-07 plans. |
+| Railway | Free plan: $0/mo with $1 non-rolling credit per month | 1 replica, 0.5 GB RAM, 1 vCPU, 0.5 GB volume. New accounts get a one-time $5 trial credit for up to 30 days (Hobby features, capped at 1 GB RAM, shared vCPU, 5 services/project), then revert to Free. Unverified GitHub accounts get restricted outbound network access. Hobby is $5/mo including $5 usage; overages: $10/GB RAM/mo, $20/vCPU/mo, $0.05/GB egress. |
+| Render | Free web services | 750 free instance hours per workspace per calendar month. Spins down after 15 minutes without traffic (~1 minute to restart). No persistent disk, single instance, no SSH, outbound SMTP ports (25/465/587) blocked, and Render may restart Free services at any time. |
+
+---
+
+## Troubleshooting
+
+### Problem: Logs show `[WARNING] Running in "debug" mode` in production
+
+**Cause:** `GIN_MODE` is unset, so Gin defaults to debug mode (verbose logging, slower).
+
+**Fix:** Set the env var on the platform (or `ENV GIN_MODE=release` in the Dockerfile):
+
+```bash
+export GIN_MODE=release
+```
+
+Or in code, before creating the router: `gin.SetMode(gin.ReleaseMode)`.
+
+### Problem: 502 "Application failed to respond" (Railway) or "no open ports detected" (Render)
+
+**Cause:** The app bound to `127.0.0.1`/`localhost`, or ignored the platform's `PORT` env var. Railway's Edge Proxy and Render both require `0.0.0.0` on the injected port.
+
+**Fix:** Read `PORT` and bind with a bare `:` prefix (which binds `0.0.0.0`):
+
+```go
+port := os.Getenv("PORT")
+if port == "" {
+	port = "8080"
+}
+srv := &http.Server{Addr: ":" + port, Handler: router}
+```
+
+On Railway, also confirm the domain's target port matches the port the app listens on.
+
+### Problem: Fly.io health checks fail and requests return 503
+
+**Cause:** The app bound to localhost instead of `0.0.0.0` on `internal_port` (Fly warns "The app is not listening on the expected address"), the machine is OOM-killed, or the app starts slower than the check's grace period.
+
+**Fix:**
+
+1. Bind `0.0.0.0:8080` to match `internal_port = 8080`
+2. Raise `grace_period` to `"15s"`-`"30s"` in `[[http_service.checks]]`
+3. If OOM: `fly scale memory 512`
+4. Give the check a dedicated `/health` endpoint that returns 200
+
+### Problem: `x509: certificate signed by unknown authority` on outbound HTTPS calls
+
+**Cause:** The final image is `scratch`, which ships no CA certificate bundle, so Go cannot verify TLS peers.
+
+**Fix:** Use `gcr.io/distroless/static-debian13` as the final stage -- it includes ca-certificates, tzdata, a root `/etc/passwd` entry, and `/tmp`:
+
+```dockerfile
+FROM gcr.io/distroless/static-debian13:nonroot
+COPY --from=build /go/bin/app /
+CMD ["/app"]
+```
+
+### Problem: `ClientIP()` returns the wrong address behind the platform proxy
+
+**Cause:** Gin trusts all proxies by default, which the Gin docs explicitly call "NOT safe" -- any client can spoof `X-Forwarded-For`.
+
+**Fix:** Restrict trusted proxies to known addresses or CIDRs, or disable proxy trust entirely:
+
+```go
+// trust a specific proxy network
+router.SetTrustedProxies([]string{"10.0.0.0/8"})
+
+// or, when not behind a proxy, return the remote address directly
+router.SetTrustedProxies(nil)
+```
+
+### Problem: Render builds with a different Go version than local
+
+**Cause:** Render's native Go runtime always auto-updates to the latest stable Go 1.x and cannot be pinned to a specific version (there is no Go equivalent of `NODE_VERSION`/`PYTHON_VERSION`).
+
+**Fix:** Deploy as a Docker service instead, pinning the builder image:
+
+```dockerfile
+FROM golang:1.26.4 AS build
+```
+
+Everything else in the Step 4 Dockerfile stays the same.

--- a/frameworks/mern.md
+++ b/frameworks/mern.md
@@ -6,7 +6,7 @@ This guide covers deploying a complete full-stack JavaScript application: a Reac
 
 ## Prerequisites
 
-- [ ] [Node.js 18+](https://nodejs.org/) installed
+- [ ] [Node.js 22+](https://nodejs.org/) installed (24 LTS recommended)
 - [ ] [Git](https://git-scm.com/downloads) installed
 - [ ] A [GitHub account](https://github.com/signup)
 - [ ] A [Render account](https://render.com/) (sign up with GitHub)
@@ -141,9 +141,9 @@ app.listen(PORT, '0.0.0.0', () => {
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "dotenv": "^16.3.0",
-    "express": "^4.18.0",
-    "mongoose": "^8.0.0"
+    "dotenv": "^17.4.0",
+    "express": "^5.2.0",
+    "mongoose": "^9.7.0"
   }
 }
 ```
@@ -194,11 +194,11 @@ git push -u origin main
 3. Connect the `mern-server` repository
 4. Configure:
    - **Name:** `mern-server`
-   - **Runtime:** Node
+   - **Language:** Node
    - **Build Command:** `npm install`
    - **Start Command:** `npm start`
    - **Instance Type:** Free
-5. Add environment variables in the **Environment** tab:
+5. Add environment variables under the **Advanced** section of the form:
    - `MONGODB_URI` = your Atlas connection string
    - `CORS_ORIGIN` = `https://<username>.github.io` (you will set this after deploying the frontend)
 6. Click **Create Web Service**
@@ -395,11 +395,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci
@@ -407,7 +407,7 @@ jobs:
         env:
           VITE_API_URL: https://mern-server.onrender.com
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -419,7 +419,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
 
 ### Enable GitHub Pages
@@ -443,9 +443,9 @@ Your frontend is live at `https://<username>.github.io/mern-client/`.
 Now that the frontend is deployed, update the `CORS_ORIGIN` on Render:
 
 1. Go to your `mern-server` service on Render
-2. Navigate to **Environment** tab
+2. Click **Environment** in the left sidebar
 3. Set `CORS_ORIGIN` to `https://<username>.github.io`
-4. Save (triggers redeploy)
+4. Choose **Save, rebuild, and deploy** (triggers redeploy)
 
 ---
 
@@ -517,7 +517,7 @@ https://<username>.github.io
 
 **Fix:**
 
-1. Check the **Environment** tab on Render -- verify `MONGODB_URI` is set
+1. Check the **Environment** page on Render (left sidebar) -- verify `MONGODB_URI` is set
 2. Go to MongoDB Atlas > **Network Access** > ensure `0.0.0.0/0` is whitelisted
 3. Check Render logs for connection error details
 
@@ -544,6 +544,18 @@ export default defineConfig({
 })
 ```
 
+### Problem: Deep links 404 on GitHub Pages
+
+**Cause:** GitHub Pages only serves static files. It knows nothing about client-side routes, so refreshing or directly opening a route like `/mern-client/todos` returns the Pages 404.
+
+**Fix:** Copy the built `index.html` to `404.html` so Pages serves the SPA for any path. Add this to the build job right after `npm run build`:
+
+```yaml
+- run: cp dist/index.html dist/404.html
+```
+
+If you add React Router, pass `basename={import.meta.env.BASE_URL}` to `BrowserRouter` so routes resolve under the `/mern-client/` subpath.
+
 ### Problem: First API call takes 30-60 seconds
 
 **Cause:** Render free tier spins down after 15 minutes of inactivity.
@@ -553,6 +565,8 @@ export default defineConfig({
 1. Show a loading spinner in the frontend while the backend wakes up
 2. Upgrade to Render Starter ($7/month) for always-on
 3. Use a service like [cron-job.org](https://cron-job.org) to ping `/health` every 14 minutes (for demos only)
+
+Note: free web services share 750 instance hours per workspace per month. One always-pinged service fits within the cap, but multiple kept-awake services will exhaust it and Render suspends all free services until the month resets.
 
 ### Problem: Environment variable is undefined in the frontend build
 

--- a/frameworks/nestjs.md
+++ b/frameworks/nestjs.md
@@ -1,0 +1,507 @@
+# Deploy NestJS
+
+> Deploy a NestJS API to Render and Railway with the correct PORT binding, @nestjs/config, a production Swagger toggle, and an optional multi-stage Dockerfile.
+
+This guide covers deploying a production-ready NestJS v11 application to two platforms: **Render** (free tier with spin-down) and **Railway** (one-time $5 trial credit, then $1/month free credit). It includes the build output layout (`dist/main.js`), environment configuration with `@nestjs/config`, turning Swagger off in production, and the `0.0.0.0` binding gotcha that causes most first-deploy 502s.
+
+## Prerequisites
+
+- [ ] [Node.js 22+](https://nodejs.org/) installed (NestJS v11 requires Node 20+; the Nest CLI requires 20.11+; 22 matches Railway's default)
+- [ ] [Git](https://git-scm.com/downloads) installed
+- [ ] A [GitHub account](https://github.com/signup)
+- [ ] A [Render account](https://render.com/) (sign up with GitHub)
+- [ ] A [Railway account](https://railway.com/)
+- [ ] [Docker](https://docs.docker.com/get-started/get-docker/) installed (optional, for the container image step)
+
+---
+
+## Step 1: Create a NestJS App
+
+```bash
+npm i -g @nestjs/cli
+# installs @nestjs/cli 11.0.23
+nest new my-nest-api
+# choose npm when prompted (or pnpm)
+cd my-nest-api
+```
+
+This scaffolds the official TypeScript starter on NestJS v11 (latest release is 11.1.27, 2026-06-15). Version notes that matter for deployment:
+
+- v11 requires **Node.js 20 or higher** (v16 and v18 support was dropped).
+- **Express v5** is the default HTTP adapter. Wildcards must be named: route `*splat`, not a bare `*`.
+- **Fastify v5** is available via `@nestjs/platform-fastify` -- see the Fastify gotcha in Step 2 if you use it.
+
+The starter's `package.json` already has the three scripts deployment depends on:
+
+```json
+{
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:prod": "node dist/main"
+  },
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  }
+}
+```
+
+`npm run build` compiles TypeScript into `dist/`, with `dist/main.js` as the entry point. Production runs plain `node` -- the Nest CLI is not needed at runtime.
+
+Add a health endpoint to `src/app.controller.ts` -- both platforms (and uptime pingers) will probe it:
+
+```ts
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  getHello(): string {
+    return this.appService.getHello();
+  }
+
+  @Get('health')
+  getHealth() {
+    return { status: 'ok' };
+  }
+}
+```
+
+For real readiness checks (database ping, memory, disk), the official docs recommend [`@nestjs/terminus`](https://docs.nestjs.com/recipes/terminus). The plain route above is enough for a free-tier deploy.
+
+Test locally:
+
+```bash
+npm run start:dev
+# Open http://localhost:3000 -> "Hello World!"
+curl http://localhost:3000/health
+# {"status":"ok"}
+```
+
+---
+
+## Step 2: Bind to PORT and 0.0.0.0
+
+Edit `src/main.ts`:
+
+```ts
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const port = process.env.PORT ?? 3000;
+  await app.listen(port, '0.0.0.0');
+}
+void bootstrap();
+```
+
+Why both arguments matter:
+
+- **`process.env.PORT`** -- Render injects `PORT` (default `10000`) and Railway injects `PORT` automatically. Hardcoding 3000 gets you a 502.
+- **`'0.0.0.0'`** -- the Express adapter binds all interfaces by default, but the official docs warn that **Fastify listens only on `127.0.0.1` by default**, which is unreachable from the platform's proxy. Passing `'0.0.0.0'` explicitly makes the same `main.ts` correct on both adapters and both platforms.
+
+---
+
+## Step 3: Environment Config with @nestjs/config
+
+```bash
+npm i --save @nestjs/config
+# installs @nestjs/config 4.0.4
+```
+
+Register it once in `src/app.module.ts`:
+
+```ts
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,  // available in every module without re-importing
+      cache: true,     // faster repeated reads of process.env
+      envFilePath: ['.env.local', '.env'],  // first match wins
+    }),
+  ],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}
+```
+
+Read values through `ConfigService` instead of touching `process.env` all over the codebase:
+
+```ts
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class AppService {
+  constructor(private readonly configService: ConfigService) {}
+
+  getHello(): string {
+    const name = this.configService.get<string>('APP_NAME') ?? 'World';
+    return `Hello ${name}!`;
+  }
+}
+```
+
+Two options worth knowing before production:
+
+- **`validate`** -- pass a synchronous validation function to `forRoot`; it runs at startup and blocks bootstrap when a required variable is missing or malformed. Fail at boot, not on the first request.
+- **`expandVariables: true`** -- enables `${OTHER_VAR}` references inside `.env` files.
+
+**v11 breaking change:** `@nestjs/config` precedence was reordered -- internal configuration (custom config files) now takes priority over environment variables, and `ignoreEnvVars` is deprecated in favor of `validatePredefined`. If you migrated from v10 and a config file value silently "wins" over a platform env var, this is why.
+
+Create a local `.env` for development and confirm it is ignored by git (the platform dashboards hold the real values):
+
+```bash
+echo "APP_NAME=Local" > .env
+grep -q "^\.env$" .gitignore || echo ".env" >> .gitignore
+```
+
+---
+
+## Step 4: Disable Swagger in Production
+
+```bash
+npm i --save @nestjs/swagger
+# installs @nestjs/swagger 11.4.5
+```
+
+Wrap the Swagger setup in a `NODE_ENV` check in `src/main.ts` -- the long-standing community pattern (tracked since nestjs/swagger issue #184) so neither the UI nor the JSON/YAML spec is served in production:
+
+```ts
+import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  if (process.env.NODE_ENV !== 'production') {
+    const config = new DocumentBuilder()
+      .setTitle('My API')
+      .setVersion('1.0')
+      .build();
+    const documentFactory = () => SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api', app, documentFactory);
+  }
+
+  const port = process.env.PORT ?? 3000;
+  await app.listen(port, '0.0.0.0');
+}
+void bootstrap();
+```
+
+In development the UI is at `http://localhost:3000/api`. If you want the machine-readable spec in production (for client generation) but no UI, keep the setup unconditional and pass `SwaggerCustomOptions` instead:
+
+```ts
+SwaggerModule.setup('api', app, documentFactory, {
+  ui: false,        // disable the UI, keep the JSON definitions
+  raw: ['json'],    // serve only the JSON spec, not YAML
+});
+```
+
+Remember to set `NODE_ENV=production` on the platform (both platforms' env var sections below) -- neither Render nor Railway sets it for you at runtime.
+
+---
+
+## Step 5: Build and Run the Production Bundle Locally
+
+```bash
+npm run build
+# compiled output lands in dist/, entry point dist/main.js
+
+NODE_ENV=production node dist/main.js
+# Windows PowerShell: $env:NODE_ENV="production"; node dist/main.js
+curl http://localhost:3000/health
+# {"status":"ok"}
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api
+# 404 -- Swagger is off in production
+```
+
+This is exactly what the platforms will run. If it fails locally, it fails there.
+
+---
+
+## Step 6: Push to GitHub
+
+```bash
+git init -b main
+git add .
+git commit -m "Initial commit"
+git remote add origin https://github.com/<username>/my-nest-api.git
+git push -u origin main
+```
+
+---
+
+## Option A: Deploy to Render
+
+### Step A1: Create the Web Service
+
+1. Go to [dashboard.render.com](https://dashboard.render.com/)
+2. Click **New** > **Web Service**
+3. Connect your GitHub repository
+4. Configure:
+   - **Name:** `my-nest-api`
+   - **Language:** Node
+   - **Build Command:** `npm ci && npm run build`
+   - **Start Command:** `node dist/main.js`
+   - **Instance Type:** Free
+5. Under **Advanced**, set **Health Check Path** to `/health`
+6. Click **Create Web Service**
+
+Do **not** use `npm start` as the start command -- the starter's `start` script runs `nest start`, which is the dev-mode CLI path. Production runs the compiled output directly.
+
+Every push to the linked branch auto-builds and deploys. Failed builds keep the previous version live.
+
+### Step A2: Pin the Node Version
+
+Render's default Node is 24.14.1 (for services created on or after 2026-04-21). The starter's `engines` range `>=20.0.0` is unbounded, and Render resolves unbounded ranges to the latest Node -- which can change under you. Override precedence: `NODE_VERSION` env var > `.node-version` file > `.nvmrc` > `package.json` engines. Simplest fix is a bounded engines range:
+
+```json
+{
+  "engines": {
+    "node": "22.x"
+  }
+}
+```
+
+### Step A3: Runtime Rules
+
+- Render injects `PORT` (default `10000`) and requires binding to `0.0.0.0` -- the `main.ts` from Step 2 satisfies both.
+- Ports 18012, 18013, and 19099 are reserved -- don't bind them.
+- The free instance has 512 MB RAM and 0.1 CPU; see Free Tier Info below for spin-down behavior.
+
+Your API is live at `https://my-nest-api.onrender.com`.
+
+---
+
+## Option B: Deploy to Railway
+
+### Step B1: Deploy from GitHub (dashboard)
+
+1. Go to [railway.com/new](https://railway.com/new)
+2. Choose **Deploy from GitHub repo** and select `my-nest-api`
+3. Railway's default builder, Railpack, detects Node with zero config. Default Node is 22 if unspecified; resolution order is `RAILPACK_NODE_VERSION` env var > `engines.node` > `.nvmrc` > `.node-version` > `mise.toml`/`.tool-versions`. The package manager is detected from the `packageManager` field or lockfiles (`pnpm-lock.yaml`, `yarn.lock`, `bun.lock`).
+
+**Fix the start command.** Railpack picks the `package.json` `start` script first, and the NestJS starter's `start` runs `nest start` -- a dev-mode trap. Either override the start command in the service **Settings** to `node dist/main.js`, or change the script so detection picks the right thing:
+
+```json
+{
+  "scripts": {
+    "start": "node dist/main"
+  }
+}
+```
+
+### Step B2: Get a Public URL
+
+1. Open the service **Settings** > **Networking** > **Public Networking**
+2. Click **Generate Domain** for a free `*.railway.app` domain
+3. Confirm the target port shown next to the domain matches the port the app listens on
+
+### Step B3: Or Deploy via the CLI
+
+```bash
+npm i -g @railway/cli
+railway init
+railway add -d postgres   # optional: provision a Postgres database
+railway up                # deploys and streams build logs
+```
+
+With a database added, inject credentials using reference variables in the service's Variables tab, e.g. `DATABASE_URL=postgresql://${{Postgres.PGUSER}}:${{Postgres.PGPASSWORD}}@${{Postgres.PGHOST}}:${{Postgres.PGPORT}}/${{Postgres.PGDATABASE}}` -- Railway resolves `${{Postgres.PGDATABASE}}`-style references at deploy time.
+
+---
+
+## Optional: Multi-Stage Dockerfile
+
+Both platforms build from a repo-root `Dockerfile` automatically (Render: select **Docker** as the language; Railway logs `Using detected Dockerfile!` when the file is named exactly `Dockerfile` -- custom paths go in a `RAILWAY_DOCKERFILE_PATH` env var). The current community-consensus pattern for NestJS:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+
+# --- build stage ---
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+# reinstall production deps only for the runtime stage
+RUN npm ci --omit=dev
+
+# --- runtime stage ---
+FROM node:22-alpine
+ENV NODE_ENV=production
+WORKDIR /app
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./
+USER appuser
+EXPOSE 3000
+CMD ["node", "dist/main.js"]
+```
+
+Create `.dockerignore` so local artifacts never leak into the build context:
+
+```
+node_modules
+dist
+.env
+```
+
+Build and test:
+
+```bash
+docker build -t my-nest-api .
+docker run -p 3000:3000 my-nest-api
+curl http://localhost:3000/health
+```
+
+Notes:
+
+- Use `node:22-slim` instead of `alpine` when you have native dependencies like `bcrypt` or `sharp` -- musl-based alpine breaks some prebuilt binaries.
+- Railway's official NestJS guide ships a single-stage `node:lts` Dockerfile ending in `CMD ["npm", "run", "start:prod"]`; the multi-stage version above produces a much smaller image, drops devDependencies, and runs as non-root.
+- On Railway, build-time env vars need `ARG` declarations per stage.
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `PORT` | Server port (Render injects it, default `10000`; Railway injects it) | `10000` |
+| `NODE_ENV` | Environment mode; the Step 4 Swagger toggle keys off it | `production` |
+| `APP_NAME` | Example app config read via `ConfigService` | `My API` |
+| `DATABASE_URL` | Database connection string (if you add one) | `postgresql://user:pass@host/db` |
+| `JWT_SECRET` | Secret for signing tokens (if you add auth) | `long-random-string` |
+
+### Set on Render
+
+1. Go to your service on Render
+2. Click the **Environment** tab
+3. Add each variable
+4. Click **Save Changes** (triggers redeploy)
+
+### Set on Railway
+
+In the dashboard: open the service's **Variables** tab, then **New Variable** (or use the **RAW Editor**, which accepts `.env` or JSON paste). Via CLI:
+
+```bash
+railway variable set NODE_ENV=production
+railway variable list
+```
+
+---
+
+## Custom Domain
+
+### Render
+
+1. Go to your service **Settings** > **Custom Domains** > **+ Add Custom Domain**, enter the domain, **Save**
+2. Configure DNS:
+
+| Type | Name | Value |
+|------|------|-------|
+| CNAME | `www` | `my-nest-api.onrender.com` |
+| A | `@` (apex) | `216.24.57.1` (Render load balancer; or use an ANAME/ALIAS record) |
+
+3. Remove any AAAA records -- Render is IPv4-only for custom domains
+4. Click **Verify** after DNS propagates. TLS certificates are auto-created and auto-renewed, with HTTP to HTTPS redirect.
+
+### Railway
+
+1. Service **Settings** > **Networking** > add a custom domain
+2. Add **both** the CNAME and TXT records Railway provides at your DNS host -- the TXT record is required for verification
+
+---
+
+## Free Tier Info
+
+| Platform | Free tier | Exact limits |
+|----------|-----------|--------------|
+| Render | Free web service: $0/mo, 512 MB RAM, 0.1 CPU | 750 free instance hours per workspace per calendar month. Spins down after 15 minutes without inbound traffic; spin-up takes about one minute. Single instance, no persistent disk (ephemeral filesystem), SMTP ports 25/465/587 blocked. The Hobby workspace plan ($0/mo) includes 5 GB outbound bandwidth/month (then $0.15/GB), 500 build pipeline minutes/month (then $5 per 1K mins), up to 25 services, 2 custom domains, and automatic TLS. Paid instances: Starter $7/mo (512 MB, 0.5 CPU), Standard $25/mo (2 GB, 1 CPU), Pro $85/mo (4 GB, 2 CPU). |
+| Railway | Free Trial: one-time $5 credit, no credit card | Trial expires after 30 days or when the $5 is spent; the account then reverts to the Free plan with $1 of free credit per month (non-accumulating). Trial limits: 1 GB RAM, shared vCPU, max 5 services per project. GitHub-verified trials get unrestricted outbound network; unverified ones are port-restricted. Paid: Hobby $5/mo with included usage, Pro $20/mo per seat. |
+
+---
+
+## Troubleshooting
+
+### Problem: 502 Bad Gateway (Render) or "Application failed to respond" (Railway)
+
+**Cause:** The app bound to `127.0.0.1`/`localhost`, or ignored the platform's `PORT` env var. Render documents this as "a web service has misconfigured its host and port"; Railway's docs say your server "should bind to the host 0.0.0.0 and listen on the port specified by the PORT environment variable".
+
+**Fix:**
+
+```ts
+const port = process.env.PORT ?? 3000;
+await app.listen(port, '0.0.0.0');
+```
+
+On Railway, also check **Settings** > **Networking**: the target port shown next to the generated domain must match the port the app listens on -- a mismatched target port is one of Railway's three documented causes of this error, alongside wrong host binding and heavy load.
+
+### Problem: Build fails with "sh: 1: nest: not found"
+
+**Cause:** The environment pruned devDependencies before the build script ran `nest build` -- `@nestjs/cli` lives in devDependencies (tracked as nestjs/nest issue #15544).
+
+**Fix:** Any one of:
+
+1. Run the build before pruning (e.g. the Dockerfile above runs `npm ci`, then `npm run build`, then `npm ci --omit=dev`)
+2. Move `@nestjs/cli` to `dependencies`
+3. Set `NPM_CONFIG_PRODUCTION=false` as a build env var so `npm ci`/`npm install` keeps devDependencies
+
+### Problem: "Cannot find module '/opt/render/project/src/dist/main'"
+
+**Cause:** `tsc` emitted to `dist/src/main.js` instead of `dist/main.js`. This happens when `tsconfig.json` includes files outside `src/` (a stray root-level `.ts` file, seed scripts, etc.), which shifts the inferred `rootDir`.
+
+**Fix:** Correct the tsconfig so only `src/` is compiled (restore `rootDir`/`include`), or point the start command at the actual output:
+
+```bash
+node dist/src/main
+```
+
+### Problem: "JavaScript heap out of memory" while building on Render's free instance
+
+**Cause:** The TypeScript build exceeds the Free instance's 512 MB RAM.
+
+**Fix:** Prefix the build with a Node heap flag -- but note it only helps within the instance's actual RAM:
+
+```
+NODE_OPTIONS=--max-old-space-size=460 npm ci && npm run build
+```
+
+`--max-old-space-size=4096` only works on instances that actually have that much memory. On the Free tier, trim the build (remove unused deps, skip source maps) or build in Docker/CI instead; if it still will not fit, a paid instance (Starter $7/mo) is the reliable fix.
+
+### Problem: Fastify app works locally but is unreachable after deploy
+
+**Cause:** By default, Fastify listens only on the localhost `127.0.0.1` interface, so the platform's proxy cannot reach it. The Express adapter binds all interfaces by default, which is why this bites Fastify users specifically.
+
+**Fix:** Pass the host explicitly:
+
+```ts
+const app = await NestFactory.create<NestFastifyApplication>(
+  AppModule,
+  new FastifyAdapter(),
+);
+await app.listen(process.env.PORT ?? 3000, '0.0.0.0');
+```
+
+### Problem: "The engine node is incompatible with this module" or "SyntaxError: Unexpected token '??='"
+
+**Cause:** The platform's Node version differs from local -- either older than a dependency requires or newer than your code was tested on. NestJS v11 itself requires Node 20+.
+
+**Fix:** Pin the runtime version on the platform:
+
+- **Render:** set a `NODE_VERSION` env var, add a `.node-version` or `.nvmrc` file, or use a bounded `engines` range like `"node": "22.x"` (precedence: `NODE_VERSION` > `.node-version` > `.nvmrc` > engines)
+- **Railway:** set `RAILPACK_NODE_VERSION`, or use `engines.node` / `.nvmrc` / `.node-version` (Railpack defaults to Node 22 when nothing is specified)

--- a/frameworks/nextjs.md
+++ b/frameworks/nextjs.md
@@ -6,7 +6,7 @@ Vercel is built by the creators of Next.js, making it the most streamlined deplo
 
 ## Prerequisites
 
-- [ ] [Node.js 18+](https://nodejs.org/) installed
+- [ ] [Node.js 20.9+](https://nodejs.org/) installed (22 or 24 LTS recommended; Next.js 16 no longer supports Node 18)
 - [ ] [Git](https://git-scm.com/downloads) installed
 - [ ] A [GitHub account](https://github.com/signup)
 - [ ] A [Vercel account](https://vercel.com/signup) (sign up with GitHub)
@@ -17,6 +17,7 @@ Vercel is built by the creators of Next.js, making it the most streamlined deplo
 
 ```bash
 npx create-next-app@latest my-nextjs-app
+# or with pnpm: pnpm create next-app my-nextjs-app
 cd my-nextjs-app
 ```
 
@@ -83,7 +84,7 @@ No GitHub Actions workflow needed. Vercel handles CI/CD natively.
 
 ## API Routes
 
-Next.js API routes are deployed as serverless functions on Vercel automatically.
+Next.js API routes are deployed as Vercel Functions automatically. They run on Fluid compute by default (enabled for all new projects since 2025-04-23), which gives in-function concurrency, bytecode caching, and automatic cold-start optimizations, with a 300s max duration on the Hobby plan.
 
 ### App Router (Recommended)
 
@@ -140,9 +141,11 @@ export default function handler(req, res) {
 
 ```bash
 vercel env add DATABASE_URL production
-vercel env add NEXT_PUBLIC_API_URL production preview development
+vercel env add NEXT_PUBLIC_API_URL   # No environment argument targets all environments
 vercel env pull .env.local   # Download to local for development
 ```
+
+The CLI accepts exactly one environment per `vercel env add` (a third argument is parsed as a git branch, not another environment). To target specific environments, run the command once per environment; omitting the environment targets all of them.
 
 ### Access in Code
 
@@ -153,6 +156,8 @@ const dbUrl = process.env.DATABASE_URL;
 // Client Component (must use NEXT_PUBLIC_ prefix)
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 ```
+
+**Tip:** If your pages query a database during the build (e.g. `generateStaticParams` or SSG page bodies), the same server env vars production needs at runtime must also exist at build time -- set them in the Vercel project env for all relevant environments. `NEXT_PUBLIC_*` values are baked into the client bundle at build time, so their build-time value is what ships to visitors.
 
 ---
 
@@ -170,13 +175,17 @@ const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 | Type | Name | Value |
 |------|------|-------|
-| A | @ | 76.76.21.21 |
+| A | @ | Copy the IP shown in **Settings** > **Domains** |
+
+Vercel no longer uses a single static IP (the old `76.76.21.21` is legacy). Each project is assigned a recommended Anycast IP -- use the exact A record value shown in your project's Domain Settings.
 
 **For subdomain (`www.yourdomain.com`):**
 
 | Type | Name | Value |
 |------|------|-------|
-| CNAME | www | cname.vercel-dns.com |
+| CNAME | www | Copy the unique CNAME shown in **Settings** > **Domains** |
+
+CNAME targets are project-specific now (e.g. `d1d4fc829fe7bc7c.vercel-dns-017.com.`); the generic `cname.vercel-dns.com` is legacy. Copy the value from your project's Domains settings, including the trailing period.
 
 ### Step 3: SSL and Redirects
 
@@ -208,7 +217,13 @@ npm install
 
 - App Router: Ensure file is at `app/api/<route>/route.js` and exports named HTTP methods (`GET`, `POST`, etc.)
 - Pages Router: Ensure file is at `pages/api/<route>.js` and exports a default function
-- Check Vercel deployment logs under **Functions** tab
+- Check runtime logs in the dashboard: select your project, then open **Logs** in the sidebar (Hobby retains 1 hour of runtime logs)
+
+### Problem: Large uploads fail even after raising `bodySizeLimit`
+
+**Cause:** Two independent limits apply. Raising Next.js `experimental.serverActions.bodySizeLimit` (e.g. to `"25mb"`) lifts the app-level 1 MB default, but Vercel's platform cap on serverless request bodies (~4.5 MB) still applies.
+
+**Fix:** Keep individual requests under ~4.5 MB -- upload large batches a few files at a time, or upload directly from the client to object storage (S3/R2) and send only the resulting URL to your API route.
 
 ### Problem: Environment variable is undefined in client code
 

--- a/frameworks/rails.md
+++ b/frameworks/rails.md
@@ -1,0 +1,378 @@
+# Deploy Ruby on Rails
+
+> Deploy a Rails 8 app to Render and Railway, with the new Rails 8 defaults (Solid Queue, Propshaft, Thruster) and a self-hosting option via Kamal 2.
+
+This guide covers deploying a production-ready Rails 8 application to Render's and Railway's free tiers, including PostgreSQL, `RAILS_MASTER_KEY` handling, the built-in `/up` health check, Solid Queue background jobs on a single database, and Tailwind via tailwindcss-rails. Current Rails is 8.1.3 (released 2026-03-24); Rails 8.x requires Ruby 3.2.0 or newer.
+
+## Prerequisites
+
+- [ ] [mise](https://mise.jdx.dev/) (or rbenv/asdf) to install Ruby 3.4+ (Ruby 3.4.10 is the latest 3.4 patch; Ruby 4.0.5 is the newest stable line)
+- [ ] [Git](https://git-scm.com/downloads) installed
+- [ ] A [GitHub account](https://github.com/signup)
+- [ ] A [Render account](https://render.com/) (sign up with GitHub)
+- [ ] (For Railway) A [Railway account](https://railway.com/)
+
+---
+
+## Step 1: Install Ruby and Rails
+
+```bash
+mise use -g ruby@3      # installs the latest Ruby 3.x (3.4.10)
+gem install rails       # installs Rails 8.1.3
+rails -v                # Rails 8.1.3
+```
+
+---
+
+## Step 2: Create a Rails App
+
+SQLite is the default database for new Rails apps, and Rails 8 production-hardens it (WAL mode, IMMEDIATE transaction defaults). That is great for a VPS, but Render and Railway free tiers have ephemeral filesystems, so create the app on PostgreSQL from the start:
+
+```bash
+rails new store --database=postgresql --css tailwind
+cd store
+```
+
+Plain `rails new store` works too (SQLite); `--css tailwind` wires up Tailwind via the tailwindcss-rails gem.
+
+Rails 8 replaces most of the old external-service stack out of the box:
+
+| Concern | Rails 8 default | Replaces |
+|---------|-----------------|----------|
+| Background jobs | Solid Queue (DB-backed Active Job backend; runs 20M jobs/day at 37signals) | Sidekiq, Resque |
+| Caching | Solid Cache (disk-backed fragment cache) | Redis, Memcached |
+| Action Cable pubsub | Solid Cable (DB polling) | Redis |
+| Asset pipeline | Propshaft (digest-stamps assets, no transpiling) | Sprockets |
+| Deployment | Kamal 2 (Docker deploys to any server) | Capistrano, PaaS |
+| Reverse proxy | Thruster (X-Sendfile, asset caching/compression) | Nginx |
+
+There is also a built-in auth scaffold if you need login:
+
+```bash
+bin/rails generate authentication   # sessions, users, password reset
+```
+
+Set up the database and run it locally:
+
+```bash
+bin/rails db:prepare
+bin/dev        # Procfile.dev: Rails server + Tailwind watcher
+```
+
+Open `http://localhost:3000`. Rails ships a health endpoint at `GET /up` (`Rails::HealthController`, mapped as `rails/health#show`): it returns 200 if the app boots without exceptions and 500 otherwise. It deliberately does not check dependencies like the database or Redis.
+
+### Tailwind on an existing app
+
+```bash
+./bin/bundle add tailwindcss-rails
+./bin/rails tailwindcss:install
+```
+
+Develop with `bin/dev` (the installer generates `Procfile.dev`) or `bin/rails tailwindcss:watch`. The gem now ships Tailwind CSS v4 -- the input file lives at `app/assets/tailwind/application.css`. To stay on v3, pin `gem "tailwindcss-rails", "~> 3.3.1"`. In production no extra build step is needed: `tailwindcss:build` auto-attaches to `assets:precompile`.
+
+---
+
+## Step 3: Get Production-Ready
+
+Rails 8.1 generates sane production defaults, so there is very little to edit. Know what you are shipping:
+
+**`config/environments/production.rb`** (generated, no changes needed):
+
+- Logs to STDOUT, tagged with request IDs, at level `info`
+- `config.silence_healthcheck_path = "/up"` keeps health-check noise out of logs
+- `config.assume_ssl = true` and `config.force_ssl = true` (commented out only when you skip Kamal at `rails new` time) -- correct behind Render/Railway's SSL-terminating proxies
+- `config.public_file_server.enabled` defaults to `true`, so Rails serves `public/` itself. No `RAILS_SERVE_STATIC_FILES` toggle needed on modern Rails.
+
+**`config/puma.rb`** (generated, no changes needed):
+
+- 3 threads per worker via `ENV.fetch("RAILS_MAX_THREADS", 3)`
+- Listens on `ENV.fetch("PORT", 3000)` -- platforms that inject `PORT` just work
+- Workers via `WEB_CONCURRENCY` (default 1; `"auto"` matches processor count, but that can be inaccurate on cloud hosts with shared CPUs -- set it explicitly)
+- `plugin :tmp_restart`, plus a Solid Queue plugin gated on the `SOLID_QUEUE_IN_PUMA` env var for single-server setups
+
+**Assets:** Propshaft digest-stamps everything into `public/assets` (mapping at `public/assets/.manifest.json`) on `assets:precompile`, and serves assets dynamically in development. It does no transpiling by design -- pair it with jsbundling-rails/cssbundling-rails if you need a bundler.
+
+**Credentials:** `config/credentials.yml.enc` is committed; `config/master.key` decrypts it and must never be committed (`rails new` gitignores it). Edit with:
+
+```bash
+bin/rails credentials:edit
+```
+
+You will paste the contents of `config/master.key` into a `RAILS_MASTER_KEY` env var on the host. The env var takes precedence over the file.
+
+**Lockfile platform:** if you develop on Windows or macOS, the deploy host is Linux. Add the platform to `Gemfile.lock` (no Linux machine needed -- bundler re-resolves and considers the new platform when picking gems):
+
+```bash
+bundle lock --add-platform x86_64-linux
+```
+
+Commit the updated `Gemfile.lock`.
+
+---
+
+## Step 4: Push to GitHub
+
+`rails new` already initialized a git repo, so just commit and push:
+
+```bash
+git add Gemfile Gemfile.lock app bin config db lib public script storage test vendor
+git add .dockerignore .gitattributes .gitignore .kamal .rubocop.yml .ruby-version Dockerfile Rakefile config.ru
+git commit -m "Initial commit"
+git branch -M main
+git remote add origin https://github.com/<username>/store.git
+git push -u origin main
+```
+
+Confirm `config/master.key` did NOT get committed (it is gitignored by default).
+
+---
+
+## Step 5: Deploy to Render
+
+### Create the database
+
+1. Go to [dashboard.render.com](https://dashboard.render.com/)
+2. Click **New** > **PostgreSQL**, pick the **Free** plan, same region as your web service
+3. After it provisions, copy the **Internal Database URL**
+
+### Add a build script
+
+Render needs one command that installs gems, builds assets, and (on the free tier) migrates. Create `bin/render-build.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -o errexit
+
+bundle install
+bundle exec rails assets:precompile
+bundle exec rails db:migrate   # free tier only -- see pre-deploy note below
+```
+
+Make it executable and commit:
+
+```bash
+chmod +x bin/render-build.sh
+git add bin/render-build.sh
+git commit -m "Add Render build script"
+git push
+```
+
+On paid instances, move `bundle exec rails db:migrate` out of the build script and into the service's **pre-deploy command** (Settings page) instead. It runs after build and before deploy, which is the right place for migrations -- but it is not available on the free tier, and it runs on a separate instance with no access to persistent disks.
+
+### Create the web service
+
+1. Click **New** > **Web Service**
+2. Connect your GitHub repository
+3. Configure:
+   - **Name:** `store`
+   - **Language:** Ruby
+   - **Build Command:** `./bin/render-build.sh`
+   - **Start Command:** `bin/rails server`
+   - **Instance Type:** Free
+4. Under **Advanced**, add environment variables:
+   - `DATABASE_URL` = the Internal Database URL from your Render Postgres
+   - `RAILS_MASTER_KEY` = the contents of `config/master.key`
+   - `WEB_CONCURRENCY` = `2`
+5. Still under **Advanced**, set the **Health Check Path** to `/up`
+6. Click **Create Web Service**
+
+Your app is live at `https://store.onrender.com`.
+
+### How Render health checks behave
+
+- Without a path set, Render only does a TCP socket check. With `/up` set, any 2xx/3xx response within 5 seconds counts as healthy.
+- During deploys, traffic is held until new instances pass health checks; a deploy is cancelled if they do not pass within 15 minutes.
+- At runtime, 15 seconds of consecutive failures pauses traffic to the instance; 60 seconds triggers an automatic restart plus a notification.
+
+---
+
+## Step 6: Deploy to Railway
+
+Either connect your GitHub repo in the dashboard, or use the CLI:
+
+```bash
+railway init
+railway up
+```
+
+Then wire it up in the dashboard:
+
+1. **Create** > **Database** > **PostgreSQL** to add Postgres to the project
+2. On your app service, open the **Variables** tab and set:
+   - `DATABASE_URL` = `${{Postgres.DATABASE_URL}}` (a reference to the Postgres service)
+   - `RAILS_MASTER_KEY` = the contents of `config/master.key`
+   - `RAILS_ENV` = `production`
+3. In **Settings** > **Deploy**, set the custom start command:
+
+```bash
+bin/rails db:prepare && bin/rails server -b ::
+```
+
+`db:prepare` migrates before boot, and `-b ::` binds IPv6, which Railway's private networking requires.
+
+4. In **Settings** > **Networking** > **Public Networking**, click **Generate Domain** for a free `railway.app` URL
+5. Set the **healthcheck path** to `/up` in service settings. Railway polls it until it gets HTTP 200 before switching traffic (default timeout 300 s; override with `RAILWAY_HEALTHCHECK_TIMEOUT_SEC`). Services with volumes still incur brief downtime on redeploy.
+
+---
+
+## Step 7: Run Solid Queue on One Database
+
+New Rails 8 apps configure Solid Queue by default -- workers and dispatchers live in `config/queue.yml`, recurring jobs (cron via Fugit) in `config/recurring.yml`. But Rails 8 puts it on a separate `queue:` database in `config/database.yml`, with its schema in `db/queue_schema.rb`, created by `db:prepare`. Free tiers give you exactly one database, so fold the queue tables into your main one:
+
+1. Create a normal migration and copy the contents of `db/queue_schema.rb` into it:
+
+```bash
+bin/rails g migration AddSolidQueueTables
+# paste the db/queue_schema.rb contents into the change method
+```
+
+2. Delete `db/queue_schema.rb`
+3. Remove `config.solid_queue.connects_to` from `config/environments/production.rb`
+4. Run `bin/rails db:prepare`
+
+Then pick how workers run:
+
+- **Separate process** (needs a paid worker service): `bin/jobs`
+- **Inside Puma** (free-tier friendly, single server): set `SOLID_QUEUE_IN_PUMA=1` in the platform's env vars. The generated `puma.rb` conditionally loads the Solid Queue plugin when that var is present.
+
+---
+
+## Alternative: Self-Host with Kamal 2
+
+If you have any VPS (Hetzner, DigitalOcean, EC2), Rails 8 apps deploy to it with zero PaaS. Every `rails new` app ships `config/deploy.yml` and `.kamal/secrets` pre-generated, with `RAILS_MASTER_KEY` already wired through `.kamal/secrets`.
+
+```bash
+gem install kamal    # current version 2.12.0
+# edit config/deploy.yml: server IP, image name, registry credentials
+kamal setup          # first deploy: installs Docker on the server via SSH,
+                     # builds/pushes the image, starts kamal-proxy on ports 80/443
+kamal deploy         # every deploy after that
+```
+
+(`kamal init` scaffolds `config/deploy.yml` for non-Rails or older apps.)
+
+The generated Dockerfile is production-grade already:
+
+- `ruby:$RUBY_VERSION-slim` base, jemalloc LD_PRELOADed to fight memory fragmentation
+- Assets precompiled at build time with `SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile` -- no real secret needed during build
+- Runs as non-root user `rails` (UID 1000)
+- CMD is `["./bin/thrust", "./bin/rails", "server"]` with `EXPOSE 80` (port 3000 without Thruster)
+
+Thruster wraps Puma (`thrust bin/rails server`) and gives you HTTP/2, X-Sendfile acceleration, compression, asset caching, and automatic Let's Encrypt TLS via the `TLS_DOMAIN` env var -- no Nginx needed. Defaults: `TARGET_PORT` 3000, `HTTP_PORT`/`HTTPS_PORT` 80/443, `CACHE_SIZE` 64 MB.
+
+With Kamal on a single VPS, the SQLite default is fully viable: WAL mode and IMMEDIATE transactions are on by default, and the disk persists.
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `RAILS_MASTER_KEY` | Decrypts `config/credentials.yml.enc`; paste the contents of `config/master.key` | `a1b2c3d4...` |
+| `DATABASE_URL` | PostgreSQL connection string | `postgres://user:pass@host/db` |
+| `RAILS_ENV` | Rails environment (Railway needs it set explicitly) | `production` |
+| `WEB_CONCURRENCY` | Puma worker processes (default 1; `auto` = CPU count, unreliable on shared CPUs) | `2` |
+| `RAILS_MAX_THREADS` | Puma threads per worker | `3` (default) |
+| `PORT` | Listen port (auto-set by the platform; Render uses 10000) | `3000` |
+| `SOLID_QUEUE_IN_PUMA` | Run Solid Queue workers inside the Puma process | `1` |
+| `TLS_DOMAIN` | Thruster auto-TLS domain (Kamal/self-host only) | `store.example.com` |
+
+### Set on Render
+
+1. Go to your service > **Environment** tab
+2. Add each variable
+3. **Save Changes** (triggers redeploy)
+
+### Set on Railway
+
+1. Go to your service > **Variables** tab
+2. Add each variable (use `${{Postgres.DATABASE_URL}}` to reference the database service)
+3. Deploy the changes
+
+---
+
+## Custom Domain
+
+### Render
+
+1. Service **Settings** > **Custom Domains** > **+ Add Custom Domain**
+2. Point a CNAME at your service's `onrender.com` subdomain:
+
+| Type | Name | Value |
+|------|------|-------|
+| CNAME | `www` | `store.onrender.com` |
+
+3. Adding a root domain auto-creates the `www` counterpart with redirects
+4. Remove any AAAA records -- Render is IPv4
+5. Click **Verify** to trigger automatic TLS certificate issuance
+
+### Railway
+
+1. Service **Settings** > **Networking** > **Public Networking** > add custom domain
+2. Add the CNAME and TXT records Railway provides at your DNS host
+3. SSL is free and auto-renewed
+
+---
+
+## Free Tier Info
+
+| Platform | Free tier | Exact limits |
+|----------|-----------|--------------|
+| Render (web) | Free web services | 512 MB RAM / 0.1 CPU. Spins down after 15 minutes without inbound traffic, ~1 minute to spin back up. 750 free instance hours per workspace per calendar month (all free services suspended if exceeded). No shell access, no persistent disks, no scaling, cannot send on SMTP ports. |
+| Render (Postgres) | 1 free DB per workspace | 256 MB RAM, 1 GB storage, no backups. Expires 30 days after creation with a 14-day grace period before deletion. |
+| Railway | $5 one-time trial credit, then Free plan | Trial: no credit card, 30 days, capped at 1 GB RAM / 2 vCPU / 5 services per project. Free plan: $1 of non-rolling credit per month at 0.5 GB RAM / 1 shared vCPU. Hobby: $5/month including $5 of usage; usage billed per second at $10/GB RAM/month and $20/vCPU/month. |
+
+---
+
+## Troubleshooting
+
+### Problem: App crashes at boot with a credentials decryption error
+
+**Cause:** `RAILS_MASTER_KEY` on the host is missing or does not match the key that encrypted `config/credentials.yml.enc`. The env var takes precedence over `config/master.key`, and Render/Railway have no `master.key` file, so a wrong or absent value fails decryption at boot.
+
+**Fix:** Paste the exact contents of local `config/master.key` into the `RAILS_MASTER_KEY` env var and redeploy. Never commit `master.key`. If the key is truly lost, re-create credentials:
+
+```bash
+bin/rails credentials:edit
+```
+
+### Problem: Bundler fails on deploy because the lockfile has no Linux platform
+
+**Cause:** `Gemfile.lock` was generated on Windows or macOS, so bundler on the Linux build host refuses to resolve gems for `x86_64-linux`.
+
+**Fix:**
+
+```bash
+bundle lock --add-platform x86_64-linux
+git add Gemfile.lock
+git commit -m "Add Linux platform to lockfile"
+git push
+```
+
+### Problem: 502 Bad Gateway on Render
+
+**Cause:** The service misconfigured its host and port. The default `config/puma.rb` already honors `PORT` (Render injects 10000) and binds correctly, so this usually means a custom start command overrode the port or bound to localhost.
+
+**Fix:** Use plain `bin/rails server` as the start command and let Puma read `PORT`. If you must pass flags, bind to `0.0.0.0`. On Railway, bind IPv6 instead: `bin/rails server -b ::`.
+
+### Problem: `relation "solid_queue_processes" does not exist`
+
+**Cause:** The Solid Queue schema was never loaded. Rails 8 keeps it in a separate `queue:` database (`db/queue_schema.rb`), and on a single-database host it never got created.
+
+**Fix:** Run `bin/rails db:prepare`. If you are on one database, do the single-database conversion from Step 7: copy `db/queue_schema.rb` into a normal migration, delete the schema file, remove `config.solid_queue.connects_to` from the environment config, then run `db:prepare` again.
+
+### Problem: SQLite data disappears after every deploy
+
+**Cause:** Render services have an ephemeral filesystem by default -- any local file changes are lost on every redeploy or restart, and persistent disks are paid-only. Rails 8's production-ready SQLite cannot survive that.
+
+**Fix:** Use the free Render Postgres (or Railway Postgres) and set `DATABASE_URL`. Keep SQLite for Kamal/VPS deploys where the disk persists.
+
+### Problem: Out-of-memory warnings on the 512 MB free instance
+
+**Cause:** Too many Puma workers for the instance size, or Ruby memory fragmentation. `WEB_CONCURRENCY=auto` matches CPU count but can be inaccurate on cloud hosts with shared CPUs.
+
+**Fix:**
+
+1. Set `WEB_CONCURRENCY=1` (or `2`) explicitly; keep the default 3 threads per worker
+2. Set `MALLOC_ARENA_MAX=2` if you are not on the default Rails Dockerfile (which already includes jemalloc)
+3. YJIT is already enabled by default on Rails 7.2+ with Ruby 3.3+ -- no action needed, but it does use some extra memory by design

--- a/frameworks/react-vite.md
+++ b/frameworks/react-vite.md
@@ -6,7 +6,7 @@ This guide covers deploying a Vite-powered React app to two platforms: **GitHub 
 
 ## Prerequisites
 
-- [ ] [Node.js 18+](https://nodejs.org/) installed
+- [ ] [Node.js 22+](https://nodejs.org/) installed (Vite requires Node 20.19+ or 22.12+; Node 18 and 20 are EOL)
 - [ ] [Git](https://git-scm.com/downloads) installed
 - [ ] A [GitHub account](https://github.com/signup)
 - [ ] (For Vercel) A [Vercel account](https://vercel.com/signup)
@@ -20,6 +20,8 @@ npm create vite@latest my-react-app -- --template react
 cd my-react-app
 npm install
 ```
+
+Using pnpm instead? `pnpm create vite my-react-app --template react`, then `pnpm install` (pnpm 11 requires Node 22.13+).
 
 Verify it runs locally:
 
@@ -46,6 +48,8 @@ export default defineConfig({
   base: '/my-react-app/',  // Must match your GitHub repo name
 })
 ```
+
+> **Tip:** To keep the root base in local dev, gate it on an env var: `base: process.env.GITHUB_PAGES === 'true' ? '/my-react-app/' : '/'`, then set `GITHUB_PAGES: 'true'` on the build step in the workflow below.
 
 ### Step 2: Create a GitHub Repository
 
@@ -82,17 +86,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -104,7 +108,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
 
 ### Step 4: Enable GitHub Pages
@@ -123,7 +127,7 @@ Your app is live at `https://<username>.github.io/my-react-app/`.
 
 ### Handle Client-Side Routing on GitHub Pages
 
-If you use React Router, create `public/404.html` to handle routing:
+If you use React Router, create `public/404.html` to handle routing. The simplest fix is to copy the built `index.html` to `404.html` in the build step (`cp dist/index.html dist/404.html` after `npm run build` in the workflow) so GitHub Pages serves the SPA for any deep link. Alternatively, use a redirect page:
 
 ```html
 <!DOCTYPE html>
@@ -146,10 +150,10 @@ If you use React Router, create `public/404.html` to handle routing:
 </html>
 ```
 
-And configure React Router with the base path:
+And configure React Router with the base path (React Router 8 installs as `react-router` and imports from `react-router`, not `react-router-dom`). The `basename` must match the `base` in `vite.config.js`, or you can pass `basename={import.meta.env.BASE_URL}` so the two never drift:
 
 ```jsx
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 
 function App() {
   return (
@@ -238,6 +242,8 @@ Access in your code:
 const API_URL = import.meta.env.VITE_API_URL;
 ```
 
+> **Tip:** For local development against a backend, skip CORS setup entirely with Vite's dev proxy in `vite.config.js`: `server: { proxy: { '/api': { target: 'http://localhost:8000', changeOrigin: true } } }`. The app calls relative `/api` paths in dev; production builds bake in `VITE_API_URL` instead.
+
 ---
 
 ## Custom Domain
@@ -252,7 +258,7 @@ const API_URL = import.meta.env.VITE_API_URL;
 
 1. Go to **Settings** > **Domains** in your Vercel project
 2. Add your domain
-3. Configure DNS as shown by Vercel (typically an A record to `76.76.21.21`)
+3. Configure DNS with the exact A/CNAME values the Vercel dashboard shows for your project (values are per-project; do not copy a generic IP from old tutorials)
 4. SSL is automatic
 
 ---

--- a/frameworks/sveltekit.md
+++ b/frameworks/sveltekit.md
@@ -1,0 +1,649 @@
+# Deploy SvelteKit
+
+> Deploy a SvelteKit 2 app to Vercel, Netlify, Cloudflare, Render, or GitHub Pages by swapping one adapter.
+
+SvelteKit doesn't have one deploy story -- it has adapters. The same app builds into a Vercel function, a Cloudflare Worker, a plain Node server, or a folder of static HTML depending on which adapter you configure in `svelte.config.js`. This guide covers creating a SvelteKit 2 / Svelte 5 app with the current `sv` CLI, then deploying it to five platforms with the right adapter for each, plus environment variables, prerendering, and the base-path dance GitHub Pages requires. Current versions as of 2026-07-06: `@sveltejs/kit` 2.69.1, `svelte` 5.56.4, `sv` CLI 0.16.2. SvelteKit 2 requires Node 18.13+, Vite 5+, and TypeScript 5+.
+
+## Prerequisites
+
+- [ ] [Node.js 20+](https://nodejs.org/) installed (SvelteKit 2 needs 18.13+ minimum; the official GitHub Pages workflow uses Node 20)
+- [ ] [Git](https://git-scm.com/downloads) installed
+- [ ] A [GitHub account](https://github.com/signup)
+- [ ] An account on your target platform: [Vercel](https://vercel.com/signup), [Netlify](https://app.netlify.com/signup), [Cloudflare](https://dash.cloudflare.com/sign-up), or [Render](https://render.com/)
+
+---
+
+## Create the App
+
+The old `npm create svelte@latest` is gone. Project creation now goes through the `sv` CLI:
+
+```bash
+npx sv create my-app
+cd my-app
+npm run dev
+```
+
+Open `http://localhost:5173` to confirm it works.
+
+`sv create` walks you through template, TypeScript, and add-on prompts. To skip the prompts (useful in CI or scripts):
+
+```bash
+npx sv create my-app --template minimal --types ts --no-add-ons --install npm
+```
+
+Available flags: `--template minimal|demo|library`, `--types ts|jsdoc` (or `--no-types`), `--add <add-ons>` / `--no-add-ons`, `--install npm|pnpm|yarn|bun|deno` (or `--no-install`), `--from-playground <url>`, `--no-dir-check`.
+
+Push it to GitHub before deploying:
+
+```bash
+git init -b main
+git add .
+git commit -m "Initial commit"
+git remote add origin https://github.com/<username>/my-app.git
+git push -u origin main
+```
+
+---
+
+## The Adapter Model
+
+Every SvelteKit build runs in two stages: `vite build` produces the optimized server and client output (prerendering happens here), then the **adapter** tunes that output for the target platform. You pick the adapter in `svelte.config.js`.
+
+The five official adapters:
+
+| Adapter | Version | Target |
+|---------|---------|--------|
+| `@sveltejs/adapter-vercel` | 6.3.4 | Vercel |
+| `@sveltejs/adapter-netlify` | 6.0.4 | Netlify |
+| `@sveltejs/adapter-cloudflare` | 7.2.9 | Cloudflare Workers Static Assets + Cloudflare Pages |
+| `@sveltejs/adapter-node` | 5.5.7 | Any Node host: Render, Railway, a VPS, Docker |
+| `@sveltejs/adapter-static` | 3.0.10 | Static hosts: GitHub Pages, or any SSG-style host |
+
+New projects ship with `@sveltejs/adapter-auto` (7.0.1), which detects Cloudflare Pages, Netlify, Vercel, Azure Static Web Apps, AWS via SST, and Google Cloud Run at build time and installs the matching adapter for you. Two catches:
+
+1. `adapter-auto` accepts **no config options**. Need `{ edge: true }` or ISR? Install the specific adapter.
+2. The docs recommend installing the specific adapter to `devDependencies` anyway -- it locks the version in your lockfile and speeds up CI.
+
+If you build outside a platform adapter-auto knows (a Render Node service, a bare VPS), the build warns:
+
+```
+Could not detect a supported production environment. See
+https://svelte.dev/docs/kit/adapters to learn how to configure your app
+to run on the platform of your choosing
+```
+
+That's your cue to install a concrete adapter. Pick your platform below.
+
+---
+
+## Option A: Vercel (adapter-vercel)
+
+Vercel deploys SvelteKit with zero configuration -- adapter-auto installs adapter-vercel at build time. But Vercel itself recommends installing the adapter explicitly for version stability:
+
+### Step 1: Install the Adapter
+
+```bash
+npm i -D @sveltejs/adapter-vercel
+```
+
+Edit `svelte.config.js` (note: this file cannot be TypeScript):
+
+```js
+import adapter from '@sveltejs/adapter-vercel';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter()
+	}
+};
+
+export default config;
+```
+
+### Step 2: Import in Vercel
+
+1. Go to [vercel.com/new](https://vercel.com/new)
+2. Click **Import Git Repository** and select `my-app`
+3. Vercel auto-detects SvelteKit -- no build settings needed
+4. Click **Deploy**
+
+Your app is live at `https://my-app.vercel.app`.
+
+### Step 3 (Optional): Tune Per-Route Config
+
+Export `config` from any route to control the deployment:
+
+```js
+// src/routes/blog/+page.server.js
+export const config = {
+	isr: {
+		expiration: 60 // seconds; required for ISR
+	}
+};
+```
+
+Adapter options include `regions` (default `["iad1"]`), `split`, `memory` (128-3008 MB, default 1024), and `maxDuration`. ISR also accepts `bypassToken` (must be at least 32 characters) and `allowQuery`. The `runtime` option (`'edge' | 'nodejs20.x' | 'nodejs22.x'`) is deprecated -- it now defaults to the Node version set in your Vercel dashboard.
+
+> **Heads up:** Vercel's Routing Middleware and `vercel.json` rewrites are NOT supported with SvelteKit. Use [server hooks](https://svelte.dev/docs/kit/hooks) (`src/hooks.server.js`) instead.
+
+---
+
+## Option B: Netlify (adapter-netlify)
+
+### Step 1: Install the Adapter
+
+```bash
+npm i -D @sveltejs/adapter-netlify
+```
+
+Edit `svelte.config.js`:
+
+```js
+import adapter from '@sveltejs/adapter-netlify';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter({
+			edge: false, // true = Deno edge functions; false = Node serverless
+			split: false // unavailable when edge: true
+		})
+	}
+};
+
+export default config;
+```
+
+### Step 2: Add netlify.toml
+
+The project root **must** contain a `netlify.toml`:
+
+```toml
+[build]
+  command = "npm run build"
+  publish = "build"
+```
+
+### Step 3: Import in Netlify
+
+1. Go to [app.netlify.com](https://app.netlify.com/)
+2. **Add new site** > **Import an existing project**
+3. Select your GitHub repo -- the `netlify.toml` supplies the build settings
+4. Click **Deploy**
+
+Netlify-specific gotchas: pages using [Netlify Forms](https://docs.netlify.com/forms/setup/) must be prerendered, or Netlify's build-time form detection won't see them. And filesystem access (`fs.readFile` etc.) does not work inside Netlify functions -- use `read()` from `$app/server` to load bundled assets instead.
+
+---
+
+## Option C: Cloudflare (adapter-cloudflare)
+
+One adapter covers both Cloudflare Workers Static Assets and Cloudflare Pages. (`adapter-cloudflare-workers`, the old Workers Sites adapter, is deprecated -- do not use it.)
+
+### New Project: One Command
+
+```bash
+npm create cloudflare@latest -- my-svelte-app --framework=svelte
+cd my-svelte-app
+npm run deploy
+```
+
+### Existing Project: Add the Adapter
+
+```bash
+npm i -D @sveltejs/adapter-cloudflare
+```
+
+Edit `svelte.config.js`:
+
+```js
+import adapter from '@sveltejs/adapter-cloudflare';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter()
+	}
+};
+
+export default config;
+```
+
+Then deploy -- Wrangler auto-generates config on first run:
+
+```bash
+npx wrangler deploy
+```
+
+For a hand-written Workers config, `wrangler.jsonc` needs:
+
+```jsonc
+{
+	"name": "my-svelte-app",
+	"main": ".svelte-kit/cloudflare/_worker.js",
+	"compatibility_date": "2026-07-06",
+	"compatibility_flags": ["nodejs_als"],
+	"assets": {
+		"binding": "ASSETS",
+		"directory": ".svelte-kit/cloudflare"
+	}
+}
+```
+
+Deploying to **Cloudflare Pages** via git instead? Use the SvelteKit preset: build command `npm run build`, output directory `.svelte-kit/cloudflare`.
+
+Bindings (KV, D1, R2, etc.) surface as `platform.env` in server code:
+
+```js
+// src/routes/+page.server.js
+export async function load({ platform }) {
+	const value = await platform.env.MY_KV.get('key');
+	return { value };
+}
+```
+
+> **Note:** `npm run preview` runs the build in Node, so `platform.env` and other Cloudflare-specific features do not apply there. Test bindings with `wrangler dev` or a preview deploy.
+
+---
+
+## Option D: Render or Railway (adapter-node)
+
+Any host that runs a Node process works with adapter-node. Render is the walkthrough here; Railway is the same adapter and the same env vars.
+
+### Step 1: Install the Adapter
+
+```bash
+npm i -D @sveltejs/adapter-node
+```
+
+Edit `svelte.config.js`:
+
+```js
+import adapter from '@sveltejs/adapter-node';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter()
+	}
+};
+
+export default config;
+```
+
+### Step 2: Test the Production Build Locally
+
+```bash
+npm run build
+node build
+```
+
+The server listens on port 3000 by default. `.env` files are NOT auto-loaded in production -- Vite only reads them at build time. To load one at runtime:
+
+```bash
+node --env-file=.env build    # Node 20.6+
+# or: node -r dotenv/config build
+```
+
+### Step 3: Deploy to Render
+
+1. Go to [dashboard.render.com](https://dashboard.render.com/)
+2. **New** > **Web Service**, connect your GitHub repo
+3. Configure:
+   - **Build Command:** `npm install && npm run build`
+   - **Start Command:** `node build/index.js`
+   - **Instance Type:** Free
+4. Add an environment variable: `ORIGIN` = `https://my-app.onrender.com` (your service URL)
+5. Click **Create Web Service**
+
+`ORIGIN` is not optional decoration -- SvelteKit needs it to construct correct URLs and to accept form submissions in production (see Troubleshooting).
+
+The deployed bundle needs `package.json` and your lockfile alongside the `build/` output; production dependencies install with `npm ci --omit dev`. Render's `npm install && npm run build` flow handles this for you.
+
+**Render static alternative:** if your app is fully prerenderable, skip the Node service. Use adapter-static (see Option E config, minus the base path) and create a Render **Static Site** with publish directory `build`.
+
+**Railway:** create a new project from your GitHub repo, keep the same build (`npm run build`) and start (`node build`) commands, and set `ORIGIN` to your Railway domain.
+
+---
+
+## Option E: GitHub Pages (adapter-static)
+
+GitHub Pages is static files only, so this route requires a fully prerendered app (no server-side form actions, no dynamic SSR). Three things make or break it: the base path, the `404.html` fallback, and a `.nojekyll` file.
+
+### Step 1: Install the Adapter
+
+```bash
+npm i -D @sveltejs/adapter-static
+```
+
+Edit `svelte.config.js`:
+
+```js
+import adapter from '@sveltejs/adapter-static';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter({
+			// defaults: pages: 'build', assets: 'build',
+			// precompress: false, strict: true
+			fallback: '404.html' // GitHub Pages serves this for deep links
+		}),
+		paths: {
+			// '/my-app' when served from username.github.io/my-app;
+			// leave empty for a username.github.io root site
+			base: process.env.BASE_PATH || ''
+		}
+	}
+};
+
+export default config;
+```
+
+`paths.base` must start, but not end, with `/` (e.g. `/my-app`), unless it is the empty string.
+
+### Step 2: Enable Prerendering
+
+adapter-static requires every page to be prerendered. Add to `src/routes/+layout.js`:
+
+```js
+export const prerender = true;
+```
+
+### Step 3: Add .nojekyll
+
+GitHub Pages runs Jekyll by default, which ignores the `_app` directory SvelteKit emits. Kill it with an empty file:
+
+```bash
+touch static/.nojekyll
+```
+
+### Step 4: Prefix Internal Links with base
+
+Every root-relative link must carry the base path, or it will 404 on `username.github.io/my-app`:
+
+```svelte
+<script>
+	import { base } from '$app/paths';
+</script>
+
+<a href="{base}/about">About</a>
+```
+
+### Step 5: Add the Deploy Workflow
+
+Create `.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+        env:
+          BASE_PATH: /${{ github.event.repository.name }}
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5
+```
+
+### Step 6: Enable GitHub Pages
+
+1. Go to **Settings** > **Pages** in your repo
+2. Under **Source**, select **GitHub Actions**
+3. Push:
+
+```bash
+git add .
+git commit -m "Add GitHub Pages deploy"
+git push origin main
+```
+
+Your app is live at `https://<username>.github.io/my-app/`.
+
+---
+
+## Prerendering
+
+Prerendering is controlled per route with a page option, exported from `+page.js`, `+page.server.js`, `+layout.js`, `+layout.server.js`, or `+server.js` (children override parents):
+
+```js
+export const prerender = true; // or false, or 'auto'
+```
+
+Dynamic routes like `/blog/[slug]` can't be discovered unless something links to them. Either let the crawler find them via `<a>` links, or export an `entries()` function (it can be async -- fetch your slugs from a CMS):
+
+```js
+// src/routes/blog/[slug]/+page.server.js
+export const prerender = true;
+
+export function entries() {
+	return [{ slug: 'hello-world' }, { slug: 'second-post' }];
+}
+```
+
+Two hard limits: pages with form actions cannot be prerendered, and reading `url.searchParams` during prerendering is forbidden (the params don't exist at build time).
+
+**SPA mode.** For a static host when you can't prerender everything, disable SSR in the root layout and give adapter-static a fallback page:
+
+```js
+// src/routes/+layout.js
+export const ssr = false;
+```
+
+The fallback filename is platform-specific: `200.html`, `index.html`, or `404.html` -- GitHub Pages uses `404.html` to serve deep-link refreshes. The docs warn that SPA mode has a large negative performance impact; prerender as many pages as possible and only fall back for the rest.
+
+**Build-time side effects.** `+page(.server).js` and `+layout(.server).js` files are imported and analyzed during the build. Guard anything with side effects:
+
+```js
+import { building } from '$app/environment';
+
+if (!building) {
+	connectToDatabase();
+}
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `ORIGIN` | Public URL of the app (adapter-node; required for correct URL and form handling) | `https://my-app.onrender.com` |
+| `PORT` | Port adapter-node listens on (default 3000) | `3000` |
+| `HOST` | Address adapter-node binds to (default 0.0.0.0) | `0.0.0.0` |
+| `BODY_SIZE_LIMIT` | Max request body size for adapter-node (default 512kb) | `512kb` |
+| `BASE_PATH` | Feeds `paths.base` in the GitHub Pages setup above | `/my-app` |
+| `PUBLIC_*` | Any variable exposed to client code (default public prefix is `PUBLIC_`) | `PUBLIC_API_URL` |
+
+### $env/static vs $env/dynamic
+
+SvelteKit gives you two ways to read private env vars, and the difference matters on every platform:
+
+```js
+// src/routes/+page.server.js
+import { API_KEY } from '$env/static/private'; // baked in at BUILD time
+import { env } from '$env/dynamic/private'; // read at RUNTIME
+
+export function load() {
+	return { fromBuild: !!API_KEY, fromRuntime: !!env.DATABASE_URL };
+}
+```
+
+- `$env/static/private` values come from `.env` files and `process.env` at build time and are **statically replaced in your code with their build-time values** -- even if the runtime value differs. Changing a dashboard env var does nothing until you rebuild. Variables here cannot begin with the public prefix (`PUBLIC_` by default).
+- `$env/dynamic/private` is read at runtime from the platform. With adapter-node it is equivalent to `process.env`. It cannot be imported into client-side code. In dev it includes `.env`; in prod, behavior depends on the adapter. Use it for secrets that rotate (database URLs, API keys on a Node host).
+
+### Setting Variables Per Platform
+
+- **Vercel:** project **Settings** > **Environment Variables**. Static values need a redeploy to take effect.
+- **Netlify:** **Site configuration** > **Environment variables**, then redeploy.
+- **Cloudflare:** plain vars in `wrangler.jsonc` / dashboard; secrets via `npx wrangler secret put NAME`. Both arrive as `platform.env`, not `process.env`.
+- **Render:** the **Environment** tab; saving triggers a redeploy. Remember `ORIGIN`.
+- **GitHub Pages:** there is no runtime -- everything is build-time. Pass values in the workflow:
+
+```yaml
+- run: npm run build
+  env:
+    BASE_PATH: /${{ github.event.repository.name }}
+    PUBLIC_API_URL: ${{ vars.PUBLIC_API_URL }}
+```
+
+---
+
+## Custom Domain
+
+### GitHub Pages
+
+1. Repo **Settings** > **Pages** > **Custom domain**, enter the domain, **Save**
+2. Configure DNS:
+
+| Type | Name | Value |
+|------|------|-------|
+| A | @ | `185.199.108.153` |
+| A | @ | `185.199.109.153` |
+| A | @ | `185.199.110.153` |
+| A | @ | `185.199.111.153` |
+| CNAME | www | `<username>.github.io` |
+
+3. Check **Enforce HTTPS** -- the checkbox can take up to 24 hours to become available while the certificate provisions
+4. With a custom domain the site serves from the root, so drop `paths.base` (set `BASE_PATH` to empty)
+
+### Vercel / Netlify / Cloudflare / Render
+
+All four follow the same pattern: add the domain in the project's domain settings, then create the exact DNS records the dashboard shows you (values are per-project -- don't copy generic IPs from old tutorials). SSL certificates are provisioned automatically on all four once DNS propagates.
+
+---
+
+## Free Tier Info
+
+| Platform | Plan | Exact limits |
+|----------|------|--------------|
+| Vercel | Hobby, $0 ("Free forever") | 100 GB/month fast data transfer, 1M function invocations/month, 4 hours/month active CPU for functions |
+| Netlify | Free, $0 | 300 credits/month. Production deploys 15 credits each, bandwidth 20 credits/GB, compute 10 credits/GB-hour, web requests 2 credits per 10k. Sites automatically pause if they exceed monthly limits |
+| Cloudflare Workers | Free, $0 | 100,000 requests/day, 10 ms CPU time per invocation. Requests to static assets are free and unlimited |
+| Render | Free, $0 | 750 instance hours per workspace per month. Free services spin down after 15 min without traffic and take about a minute to spin back up. No persistent disks |
+| Railway | Trial, then Free | One-time $5 trial credit valid up to 30 days (1 GB RAM, shared vCPU, max 5 services/project). Afterward $1 of credit per month, does not roll over |
+| GitHub Pages | Free, $0 | Published site max 1 GB, soft bandwidth limit 100 GB/month, soft limit 10 builds/hour (does not apply when deploying via a custom Actions workflow) |
+
+For a mostly-static SvelteKit site, Cloudflare's unlimited static asset requests are hard to beat.
+
+---
+
+## Troubleshooting
+
+### Problem: Build warns "Could not detect a supported production environment"
+
+**Cause:** You're building with the default adapter-auto on a platform it doesn't recognize (Render, Railway, a VPS, plain CI). adapter-auto only detects Cloudflare Pages, Netlify, Vercel, Azure Static Web Apps, AWS via SST, and Google Cloud Run.
+
+**Fix:** Install and configure a concrete adapter:
+
+```bash
+npm i -D @sveltejs/adapter-node
+```
+
+```js
+// svelte.config.js
+import adapter from '@sveltejs/adapter-node';
+```
+
+### Problem: "Cross-site POST form submissions are forbidden" in production
+
+**Cause:** SvelteKit's CSRF protection. Form actions work in dev but fail in production with adapter-node because the app doesn't know its own public URL, so every POST looks cross-site.
+
+**Fix:** Set the `ORIGIN` environment variable on the host to the exact public URL:
+
+```
+ORIGIN=https://my-app.onrender.com
+```
+
+(You can also configure `csrf.checkOrigin` in `svelte.config.js`, but setting `ORIGIN` is the intended fix -- don't disable CSRF protection to make an error go away.)
+
+### Problem: "The following routes were marked as prerenderable, but were not prerendered"
+
+**Cause:** The prerender crawler starts from `kit.prerender.entries` (default `['*']`, all non-dynamic routes) and follows `<a>` links. A route marked `prerender = true` that nothing links to is never reached -- typical for dynamic routes like `/blog/[slug]`.
+
+**Fix:** Export an `entries()` function from the route (see Prerendering above), add the paths to `kit.prerender.entries` in `svelte.config.js`, or use `export const prerender = 'auto'` if the route may also be server-rendered.
+
+### Problem: Prerender build fails on a linked 404
+
+**Cause:** `kit.prerender.handleHttpError` defaults to `'fail'` -- any crawled link that returns an error status breaks the build.
+
+**Fix:** Fix the dead link, or tell SvelteKit which errors to tolerate:
+
+```js
+// svelte.config.js
+const config = {
+	kit: {
+		prerender: {
+			handleHttpError: ({ path, referrer, message }) => {
+				if (path === '/not-found' && referrer === '/blog/how-we-built-our-404-page') {
+					return; // expected; ignore
+				}
+				throw new Error(message);
+			}
+		}
+	}
+};
+```
+
+`'warn'` or `'ignore'` also work as blanket values, but the handler keeps you honest about which 404s are intentional.
+
+### Problem: Blank page or broken assets on GitHub Pages
+
+**Cause:** One of the three GitHub Pages requirements is missing: `paths.base` isn't set (assets resolve to `username.github.io/_app/...` instead of `username.github.io/my-app/_app/...`), internal links aren't prefixed with `{base}`, or Jekyll is eating the `_app` directory.
+
+**Fix:** Set `paths.base` to `/<repo-name>` (via `BASE_PATH` in the workflow), prefix links with `base` from `$app/paths`, and make sure `static/.nojekyll` exists:
+
+```bash
+touch static/.nojekyll
+git add static/.nojekyll
+git commit -m "Add .nojekyll"
+git push
+```
+
+### Problem: Changed an env var in the dashboard but the app still uses the old value
+
+**Cause:** The value is imported from `$env/static/private` (or `$env/static/public`), which is statically injected into the bundle at build time. The running code literally contains the old string.
+
+**Fix:** Either trigger a rebuild/redeploy after every env change, or switch runtime-configurable values to the dynamic module:
+
+```js
+import { env } from '$env/dynamic/private';
+
+const dbUrl = env.DATABASE_URL; // read when the request runs, not when the build ran
+```

--- a/guides/aws-amplify.md
+++ b/guides/aws-amplify.md
@@ -6,18 +6,20 @@ Full-stack serverless deployment with CI/CD, preview environments, and auto-clea
 
 - AWS account with Amplify access
 - GitHub repository
-- Node.js 20+
+- Node.js 22+
 
 ## Setup
 
 ### 1. Create Amplify App
 
 ```bash
-# Install Amplify CLI
-npm install -g @aws-amplify/cli
+# Scaffold a new Amplify Gen 2 project
+# (the Gen 1 CLI, @aws-amplify/cli + amplify init, is in maintenance mode
+# and reaches end of life on 2027-05-01)
+npm create amplify@latest
 
-# Initialize in your project
-amplify init
+# Local dev: deploy a per-developer cloud sandbox
+npx ampx sandbox
 ```
 
 Or use the AWS Console: Amplify > Create new app > Connect GitHub repo.
@@ -32,12 +34,10 @@ backend:
   phases:
     build:
       commands:
+        - npm ci --cache .npm --prefer-offline
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
-    preBuild:
-      commands:
-        - npm ci
     build:
       commands:
         - npm run build
@@ -47,8 +47,11 @@ frontend:
       - '**/*'
   cache:
     paths:
+      - .npm/**/*
       - node_modules/**/*
 ```
+
+Amplify injects `$AWS_BRANCH` and `$AWS_APP_ID` automatically. The `--cache .npm` flag is what makes the `.npm/**/*` cache entry effective, so warm builds skip re-downloading packages.
 
 ### 3. GitHub Actions CI/CD (Recommended)
 
@@ -69,12 +72,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -88,9 +91,14 @@ jobs:
           aws amplify create-branch --app-id ${{ secrets.AMPLIFY_APP_ID }} --branch-name $BRANCH_NAME 2>/dev/null || true
           ZIP_FILE=$(mktemp).zip
           cd dist && zip -r $ZIP_FILE . && cd ..
-          UPLOAD_URL=$(aws amplify create-deployment --app-id ${{ secrets.AMPLIFY_APP_ID }} --branch-name $BRANCH_NAME --query 'zipUploadUrl' --output text)
-          curl -T $ZIP_FILE "$UPLOAD_URL"
+          DEPLOYMENT=$(aws amplify create-deployment --app-id ${{ secrets.AMPLIFY_APP_ID }} --branch-name $BRANCH_NAME)
+          JOB_ID=$(echo "$DEPLOYMENT" | jq -r '.jobId')
+          UPLOAD_URL=$(echo "$DEPLOYMENT" | jq -r '.zipUploadUrl')
+          curl -X PUT -T $ZIP_FILE "$UPLOAD_URL"
+          aws amplify start-deployment --app-id ${{ secrets.AMPLIFY_APP_ID }} --branch-name $BRANCH_NAME --job-id $JOB_ID
 ```
+
+`create-deployment` only stages the upload URL -- without `start-deployment` (using the returned `jobId`) the zip is never published. Poll `aws amplify get-job` if you need to wait for SUCCEED/FAILED.
 
 ### 4. Preview Environments (Per PR)
 
@@ -101,15 +109,24 @@ Add a second workflow for PR previews:
 name: Preview
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, closed]
 
 jobs:
   preview:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
-      # Same as deploy but with branch name: pr-${{ github.event.number }}
-      # Comment the preview URL on the PR
-      # Auto-delete on PR close
+      # Same as deploy, but:
+      # - create the branch as pr-${{ github.event.number }} with --no-enable-auto-build
+      # - deploy backend: npx ampx pipeline-deploy --branch pr-N --app-id <id>
+      # - preview URL: https://pr-N.<appId>.amplifyapp.com (comment it on the PR)
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      # Delete the Amplify branch, then delete the backend CloudFormation
+      # stacks named amplify-<appId>-pr-N-branch-* -- deleting the hosting
+      # branch alone does not remove Gen 2 backend resources
 ```
 
 ## Backend Services
@@ -126,11 +143,14 @@ All defined as Infrastructure as Code via CDK.
 
 ## Cost
 
-- Free tier: 1000 build minutes/month, 5 GB hosting, 15 GB bandwidth
-- After free tier: ~$0.01/build minute, $0.15/GB served
+- Monthly allowances: 1,000 build minutes, 5 GB stored on the CDN, 15 GB served, 500K SSR requests, 100 GB-hours SSR duration
+- Beyond that: $0.01/build minute (standard; $0.025 Large, $0.10 XLarge), $0.023/GB/month storage, $0.15/GB served, $0.30 per 1M SSR requests + $0.20/GB-hour SSR duration
+- AWS Free Tier changed on 2025-07-15: new accounts get $100 in credits at signup (up to $200 total) on a 6-month Free plan; the old 12-month free tier only applies to accounts created before that date
 
 ## Tips
 
-- Use OIDC role assumption (no static AWS keys in GitHub secrets)
+- Use OIDC role assumption (no static AWS keys in GitHub secrets): set `permissions: id-token: write` and pass `role-to-assume`
+- Scope OIDC roles per environment: trust `sub = repo:OWNER/REPO:pull_request` for the preview role and `sub = repo:OWNER/REPO:ref:refs/heads/main` for production, so PR workflows physically cannot assume the production role
 - Set up auto-cleanup to delete preview environments on PR close
 - Use `amplify_outputs.json` to connect frontend to backend services
+- Run the backend deploy before the frontend build -- `ampx pipeline-deploy` generates `amplify_outputs.json`, and building first ships a frontend without its API endpoints. If your bundler does not copy it into `dist`, add a copy step (e.g. a Vite `closeBundle` hook) and verify `dist/amplify_outputs.json` exists post-build

--- a/guides/aws-ecs.md
+++ b/guides/aws-ecs.md
@@ -8,9 +8,9 @@ AWS ECS (Elastic Container Service) is a fully managed container orchestration s
 
 - [ ] An [AWS account](https://aws.amazon.com/free/) with billing enabled
 - [ ] [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed and configured
-- [ ] [Docker](https://docs.docker.com/get-docker/) installed locally
+- [ ] [Docker](https://docs.docker.com/get-started/get-docker/) installed locally
 - [ ] [Git](https://git-scm.com/downloads) installed locally
-- [ ] (Optional) [jq](https://jqlang.github.io/jq/download/) for parsing JSON output
+- [ ] (Optional) [jq](https://jqlang.org/download/) for parsing JSON output
 - [ ] AWS CLI configured with credentials:
 
 ```bash
@@ -67,7 +67,7 @@ Create `package.json`:
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.0"
+    "express": "^5.0.0"
   }
 }
 ```
@@ -77,12 +77,12 @@ Create `package.json`:
 Create `Dockerfile`:
 
 ```dockerfile
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 
-FROM node:20-alpine
+FROM node:24-alpine
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
@@ -568,10 +568,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -623,7 +623,7 @@ Go to your repository **Settings** > **Secrets and variables** > **Actions** and
 | `AWS_ACCESS_KEY_ID` | IAM user access key ID |
 | `AWS_SECRET_ACCESS_KEY` | IAM user secret access key |
 
-> **Tip:** For better security, use [OIDC with GitHub Actions](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) instead of long-lived credentials.
+> **Tip:** For better security, use [OIDC with GitHub Actions](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) instead of long-lived credentials -- it is the approach AWS and GitHub now recommend. Add `permissions: id-token: write` to the job and pass `role-to-assume` to `configure-aws-credentials` (an IAM role trusting `token.actions.githubusercontent.com` with the `sub` claim scoped to your repo and branch, e.g. `repo:OWNER/REPO:ref:refs/heads/main`). No AWS keys stored as secrets.
 
 ---
 
@@ -642,23 +642,32 @@ aws ecs update-service \
   --cluster $ECS_CLUSTER_NAME \
   --service my-ecs-app-service \
   --force-new-deployment
+
+# Wait for the rollout to stabilize before calling it done
+aws ecs wait services-stable \
+  --cluster $ECS_CLUSTER_NAME \
+  --services my-ecs-app-service
 ```
 
 ---
 
 ## Cost: Free Tier and Pricing
 
-### AWS Free Tier (first 12 months)
+### AWS Free Tier
 
-| Service | Free Allowance |
+For AWS accounts created on or after July 15, 2025, the 12-month free tier no longer exists. New accounts choose a Free or Paid account plan and get USD $100 in credits at signup, plus up to another USD $100 for completing activities (up to $200 total). The Free plan lasts up to 6 months or until credits run out, whichever comes first -- then the account closes unless upgraded to Paid. 30+ always-free services remain, and data transfer from AWS Regions to the internet is free up to 100 GB/month for all customers.
+
+Accounts created before July 15, 2025 keep the legacy 12-month free tier:
+
+| Service | Free Allowance (legacy accounts only) |
 |---------|---------------|
 | EC2 (t2.micro/t3.micro) | 750 hours/month |
 | ECS | No additional charge (pay for underlying compute) |
 | ECR | 500 MB storage/month |
 | ALB | 750 hours + 15 LCUs/month |
-| Data Transfer | 15 GB out/month |
+| Data Transfer | 100 GB out/month (all accounts) |
 
-> **Important:** Fargate is **not** included in the free tier. The EC2 launch type with a t2.micro is free-tier eligible.
+> **Important:** Fargate has no always-free allowance. On new (credits-based) accounts, the signup credits simply offset Fargate's pay-as-you-go pricing. On legacy accounts, only the EC2 launch type with a t2.micro is free-tier eligible.
 
 ### Fargate Pricing (us-east-1)
 
@@ -671,8 +680,9 @@ aws ecs update-service \
 
 - vCPU: 2 x 0.25 x $0.04048 x 730 hrs = ~$14.75
 - Memory: 2 x 0.5 x $0.004445 x 730 hrs = ~$3.25
-- ALB: ~$16/month (after free tier)
-- **Total: ~$34/month**
+- ALB: ~$16.4/month ($0.0225/hour) plus LCU charges ($0.008/LCU-hour)
+- Public IPv4 addresses: 4 x $0.005 x 730 hrs = ~$14.60 (2 task IPs with `assignPublicIp=ENABLED` + 2 ALB IPs across 2 AZs; AWS charges $0.005/hour per public IPv4 since February 1, 2024)
+- **Total: ~$48-49/month**
 
 Use **Fargate Spot** for non-critical workloads to save up to 70%.
 

--- a/guides/ci-cd-templates.md
+++ b/guides/ci-cd-templates.md
@@ -49,12 +49,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -66,10 +66,10 @@ jobs:
           VITE_API_URL: ${{ vars.VITE_API_URL }}
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -82,7 +82,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
 
 **Prerequisites:**
@@ -109,12 +109,11 @@ Vercel has native Git integration, so you typically do NOT need a GitHub Actions
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
   "framework": "nextjs",
-  "regions": ["iad1"],
-  "env": {
-    "NEXT_PUBLIC_API_URL": "@api-url"
-  }
+  "regions": ["iad1"]
 }
 ```
+
+Do not use the `env` property in `vercel.json` -- Vercel recommends against it (the `@secret-name` indirection is legacy Vercel Secrets). Define environment variables in Project Settings in the dashboard instead.
 
 **If you DO need a custom GitHub Actions workflow** (e.g., to run tests before deploying):
 
@@ -132,12 +131,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -146,12 +145,26 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Pull Vercel environment
+        run: npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build
+        run: npx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
       - name: Deploy to Vercel
-        run: npx vercel deploy --prod --token ${{ secrets.VERCEL_TOKEN }}
+        run: npx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 ```
+
+This is Vercel's recommended flow: build in CI, then upload only the prebuilt artifacts (`--prebuilt`), so Vercel does not rebuild. For preview deploys, use `--environment=preview` in the pull step and drop `--prod` from build and deploy.
 
 **Getting Vercel credentials:**
 - `VERCEL_TOKEN`: Account Settings > Tokens > Create
@@ -179,12 +192,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -234,12 +247,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: pip
 
       - name: Install dependencies
@@ -279,12 +292,31 @@ services:
     startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
     envVars:
       - key: PYTHON_VERSION
-        value: "3.12"
+        value: "3.14"
       - key: DATABASE_URL
         fromDatabase:
           name: my-db
           property: connectionString
 ```
+
+**Tip: free-tier keep-alive.** Render free services sleep after 15 minutes of inactivity (and Neon free-tier database branches archive after 24 hours idle), causing cold starts of 15-25 seconds. A scheduled workflow that pings an unauthenticated health endpoint keeps them warm at near-zero cost:
+
+```yaml
+name: Keep Alive
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping health endpoint
+        run: curl --silent --max-time 30 https://your-app.onrender.com/health || echo "ignoring failure"
+```
+
+The `|| echo` keeps the job green on transient failures so you do not get noise from failed runs.
 
 ---
 
@@ -314,12 +346,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install and test
@@ -335,10 +367,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -401,12 +433,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install and test
@@ -419,7 +451,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master
@@ -479,12 +511,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -505,7 +537,7 @@ jobs:
       url: https://staging.example.com
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Deploy to Staging
         run: |
@@ -521,7 +553,7 @@ jobs:
       url: https://example.com
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Deploy to Production
         run: |
@@ -571,10 +603,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -594,7 +626,7 @@ Every pull request gets an automatic preview deployment. Vercel posts a comment 
 
 ### Netlify (Automatic)
 
-Same as Vercel. Netlify automatically creates deploy previews for PRs and posts a comment with the URL. Enable under Site > Build & deploy > Deploy notifications.
+Same as Vercel. Netlify automatically creates deploy previews for PRs (enabled by default, toggled under Project configuration > Build & deploy > Continuous deployment > Branches and deploy contexts). PR comments with the preview URL are configured under Project configuration > Notifications > Deploy notifications.
 
 ### Manual Preview Deploys (Other Platforms)
 
@@ -611,7 +643,7 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Fly CLI
         uses: superfly/flyctl-actions/setup-flyctl@master
@@ -626,7 +658,7 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Comment PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({
@@ -680,17 +712,21 @@ Caching dramatically speeds up CI builds by reusing downloaded dependencies.
 
 ```yaml
 - name: Setup Node.js
-  uses: actions/setup-node@v4
+  uses: actions/setup-node@v6
   with:
-    node-version: 20
+    node-version: 22
     cache: npm   # Automatically caches ~/.npm based on package-lock.json
 ```
+
+The `cache` input also supports `pnpm` and `yarn`. For pnpm, run `pnpm/action-setup@v4` BEFORE `setup-node` (the cache step fails if pnpm is not on PATH yet), then install with `pnpm install --frozen-lockfile`. Current pnpm is v11, which requires Node 22.13+.
+
+Tip: pin the Node version in `.nvmrc` and reference it with `node-version-file: ".nvmrc"` instead of `node-version` so CI and local never drift.
 
 Or manual cache control:
 
 ```yaml
 - name: Cache node_modules
-  uses: actions/cache@v4
+  uses: actions/cache@v6
   with:
     path: node_modules
     key: node-modules-${{ hashFiles('package-lock.json') }}
@@ -702,9 +738,9 @@ Or manual cache control:
 
 ```yaml
 - name: Setup Python
-  uses: actions/setup-python@v5
+  uses: actions/setup-python@v6
   with:
-    python-version: "3.12"
+    python-version: "3.14"
     cache: pip   # Automatically caches pip downloads based on requirements.txt
 ```
 
@@ -712,7 +748,7 @@ Or manual cache:
 
 ```yaml
 - name: Cache pip
-  uses: actions/cache@v4
+  uses: actions/cache@v6
   with:
     path: ~/.cache/pip
     key: pip-${{ hashFiles('requirements.txt') }}
@@ -720,14 +756,29 @@ Or manual cache:
       pip-
 ```
 
+### uv (Python, alternative)
+
+The [uv](https://docs.astral.sh/uv/) package manager has an official setup action with caching built in, replacing the setup-python + cache boilerplate:
+
+```yaml
+- name: Setup uv
+  uses: astral-sh/setup-uv@v8
+  with:
+    python-version: "3.14"
+    enable-cache: true
+
+- name: Install dependencies
+  run: uv sync
+```
+
 ### Docker Layer Caching
 
 ```yaml
 - name: Set up Docker Buildx
-  uses: docker/setup-buildx-action@v3
+  uses: docker/setup-buildx-action@v4
 
 - name: Build and push
-  uses: docker/build-push-action@v6
+  uses: docker/build-push-action@v7
   with:
     context: .
     push: true
@@ -754,11 +805,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [22, 24]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -774,11 +825,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -796,10 +847,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18, 20]
+        node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -865,6 +916,7 @@ jobs:
 3. **Check the event:** `on: push` triggers on push; `on: pull_request` triggers on PR events. They are different.
 4. **Disabled workflows:** Go to Actions tab and check if the workflow is disabled.
 5. **Syntax error:** A YAML syntax error silently prevents the workflow from running. Validate with `actionlint` or the GitHub Actions VS Code extension.
+6. **Bot commits:** Pushes made by a workflow using the default `GITHUB_TOKEN` (e.g., a scheduled job committing generated files) never trigger `on: push` -- this prevents infinite loops. To chain workflows, use `on: workflow_run: { workflows: ["First Workflow"], types: [completed] }` in the second workflow and gate its jobs with `github.event.workflow_run.conclusion == 'success'`.
 
 ### Build Timeout
 

--- a/guides/cloudflare-pages.md
+++ b/guides/cloudflare-pages.md
@@ -4,11 +4,13 @@
 
 Cloudflare Pages is a deployment platform for frontend and full-stack applications. It supports static site hosting with automatic builds from Git, server-side rendering with Cloudflare Functions (Workers), and edge-native data stores like D1 (SQLite) and KV (key-value). If you already use Cloudflare for DNS, adding Pages is seamless.
 
+> **Note:** Since April 2025, Cloudflare recommends starting new projects on [Workers with static assets](https://developers.cloudflare.com/workers/static-assets/) instead of Pages. Pages remains fully supported (and static asset requests are free on both), but all new investment goes into Workers, and some features are Workers-only (Durable Objects, Cron Triggers, fuller observability). An official [migration guide](https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/) covers moving Pages projects to Workers.
+
 ## Prerequisites
 
 - [ ] A [Cloudflare account](https://dash.cloudflare.com/sign-up) (free)
 - [ ] [Git](https://git-scm.com/downloads) installed locally
-- [ ] [Node.js 18+](https://nodejs.org/)
+- [ ] [Node.js 22+](https://nodejs.org/)
 - [ ] (Optional) [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/): `npm install -g wrangler`
 
 ---
@@ -26,7 +28,7 @@ The fastest way to get started is connecting a GitHub repository.
 | Framework | Build Command | Output Directory |
 |-----------|---------------|------------------|
 | React (Vite) | `npm run build` | `dist` |
-| Next.js | `npx @cloudflare/next-on-pages@1` | `.vercel/output/static` |
+| Next.js (static export) | `npm run build` | `out` |
 | Vue (Vite) | `npm run build` | `dist` |
 | Astro | `npm run build` | `dist` |
 | SvelteKit | `npm run build` | `.svelte-kit/cloudflare` |
@@ -105,30 +107,35 @@ No special configuration needed. Works out of the box.
 
 ### Next.js
 
-Next.js on Cloudflare Pages uses the `@cloudflare/next-on-pages` adapter.
+The old `@cloudflare/next-on-pages` adapter is deprecated. On Pages, deploy Next.js as a static export. For full SSR, use Workers with the [OpenNext adapter](https://opennext.js.org/cloudflare) (`@opennextjs/cloudflare`) instead.
 
 ```bash
 npx create-next-app@latest my-next-app
 cd my-next-app
-npm install @cloudflare/next-on-pages
 ```
 
-Update `next.config.js`:
+Update `next.config.js` for static export:
 
 ```js
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',  // For static export
-  // OR omit 'output' and use @cloudflare/next-on-pages for full SSR
+  output: 'export',  // Static export -- required for Pages
 };
 
 module.exports = nextConfig;
 ```
 
-For full SSR support, use the adapter as the build command:
+Build settings:
+- **Build command:** `npm run build`
+- **Output directory:** `out`
 
-- **Build command:** `npx @cloudflare/next-on-pages@1`
-- **Output directory:** `.vercel/output/static`
+For full SSR support, deploy to Workers with OpenNext instead of Pages:
+
+```bash
+npm install @opennextjs/cloudflare
+npx opennextjs-cloudflare build
+npx opennextjs-cloudflare deploy
+```
 
 ### Vue (Vite)
 
@@ -459,6 +466,8 @@ export async function onRequestGet(context) {
 
 > **Note:** Variables set in the dashboard are encrypted at rest. Use `wrangler pages secret put` for sensitive values instead of putting them in `wrangler.toml`.
 
+> **Tip:** For OAuth on a static frontend, never ship the client secret to the browser. Put the token exchange (e.g., the `/callback` code-for-token step) in a Pages Function or a small Worker, store the secret with `wrangler pages secret put` (or `wrangler secret put` for a Worker), and keep only non-secret config like `CLIENT_ID` in `wrangler.toml` `[vars]`.
+
 ---
 
 ## Custom Domain
@@ -545,7 +554,7 @@ Create a `_headers` file in your output directory:
 | **Bandwidth** | Unlimited |
 | **Builds** | 500/month |
 | **Concurrent builds** | 1 |
-| **Custom domains** | Unlimited |
+| **Custom domains** | 100 per project |
 | **Pages Functions requests** | 100,000/day |
 | **D1 database storage** | 5 GB |
 | **D1 reads** | 5 million/day |
@@ -574,8 +583,8 @@ Key details:
 
 1. Check the build logs in the Cloudflare dashboard > **Deployments** > click the failed deploy
 2. Set the correct Node.js version:
-   - Add a `NODE_VERSION` environment variable (e.g., `18` or `20`)
-   - Or add an `.nvmrc` file to your repo root: `18`
+   - Add a `NODE_VERSION` environment variable (e.g., `22` or `24`)
+   - Or add an `.nvmrc` or `.node-version` file to your repo root: `22`
 3. Make sure all dependencies are in `package.json`:
 
 ```bash
@@ -684,7 +693,7 @@ export async function onRequestGet(context) {
 }
 ```
 
-3. Keep your function bundle small. Cloudflare limits scripts to 1 MB on the free tier (10 MB on paid).
+3. Keep your function bundle small. Cloudflare limits scripts to 3 MB (after gzip) on the free tier (10 MB on paid).
 
 ### Problem: Custom domain shows "Error 522" or "Error 524"
 

--- a/guides/cockroachdb.md
+++ b/guides/cockroachdb.md
@@ -1,0 +1,478 @@
+# CockroachDB
+
+> Set up a free CockroachDB Basic cluster (serverless, PostgreSQL-compatible distributed SQL), get a connection string, and use it from Node.js and Python.
+
+CockroachDB Cloud is a managed distributed SQL database that speaks the PostgreSQL wire protocol, so standard `pg`, `psycopg`, Prisma, and SQLAlchemy code works with minimal changes. On 2024-09-25 Cockroach Labs renamed its plans: Serverless became **Basic**, Dedicated became **Advanced**, and a new **Standard** plan entered Preview. The free tier survived the rename: every pay-as-you-go organization gets $15 of resource consumption free each month (equivalent to 50 million Request Units and 10 GiB of storage), shared across all Basic clusters in the org. One catch: a payment method must be on file to receive the recurring monthly benefit -- you are only charged for usage above the free $15. New accounts also get a one-time $400 trial credit with no credit card required.
+
+## Prerequisites
+
+- [ ] A [CockroachDB Cloud account](https://cockroachlabs.cloud/) (sign up with GitHub, Google, or email)
+- [ ] [Node.js 22+](https://nodejs.org/) (for Node.js usage)
+- [ ] [Python 3.12+](https://www.python.org/downloads/) (for Python usage)
+- [ ] (Optional) [ccloud CLI](https://www.cockroachlabs.com/docs/cockroachcloud/ccloud-get-started) v0.6.12 for terminal-based cluster management
+- [ ] (Optional) [cockroach client](https://www.cockroachlabs.com/docs/stable/install-cockroachdb-mac) v26.2 for a local SQL shell
+
+---
+
+## Step 1: Create a Basic Cluster
+
+1. Log in to the [Cloud Console](https://cockroachlabs.cloud/)
+2. On the **Clusters** page, click **Create Cluster**
+3. Select the **Basic** plan
+4. Choose a cloud provider: **GCP** or **AWS** (Azure is not supported for Basic)
+5. Pick a region close to your app's deployment platform. You can add up to 6 regions total via **Add regions**
+6. Set capacity:
+   - **Start for free** (if eligible) -- runs within the free monthly allotment
+   - **Unlimited** -- scale on demand, pay for overage
+   - **Set a monthly limit** -- hard cap on spend
+7. Name the cluster: 6-20 characters, lowercase letters, numbers, and dashes only. The name is **not editable later**
+8. Click **Create cluster**
+
+The cluster provisions quickly with a default database called `defaultdb`. Basic clusters automatically run the latest stable CockroachDB version (v26.2 as of 2026-07-06), so there is nothing to upgrade or patch yourself.
+
+---
+
+## Step 2: Create a SQL User
+
+1. On your cluster's page, click **Connect** (top right)
+2. Create a SQL user when prompted -- the console generates a password for you
+3. Store the password immediately. It is shown once
+
+Via the ccloud CLI instead:
+
+```bash
+ccloud cluster user create my-app-db appuser
+# Prompts for a password, creates an admin SQL user
+```
+
+---
+
+## Step 3: Get Your Connection String
+
+In the **Connect** dialog, pick a connection method:
+
+- **Command line** -- ready-made `cockroach sql` command
+- **General connection string** -- for drivers and ORMs (use this one)
+- **Connection parameters** -- host/port/user broken out
+- **CockroachDB Client** -- client install instructions
+
+The general connection string looks like this:
+
+```
+postgresql://appuser:password@my-app-db-1234.cockroachlabs.cloud:26257/defaultdb?sslmode=verify-full
+```
+
+Format breakdown:
+
+| Part | Value |
+|------|-------|
+| Host | `<cluster-name>.cockroachlabs.cloud` |
+| Port | `26257` |
+| Database | `defaultdb` (or one you create) |
+| SSL | `sslmode=verify-full` (required) |
+
+> **Important:** Special characters in passwords must be URL-encoded. `password!` becomes `password%21`. If your driver rejects the string, encode the password first.
+
+The cluster's CA certificate is signed by Let's Encrypt, which most systems already trust -- connections usually work with no certificate download. If your system does not trust it, the Connect dialog provides an OS-specific download command that places the cert in the default PostgreSQL certificate directory.
+
+For JDBC (Java), the format is:
+
+```
+jdbc:postgresql://{host}:{port}/{database}?password={password}&sslmode=verify-full&user={username}
+```
+
+---
+
+## Alternative: ccloud CLI
+
+The `ccloud` CLI manages clusters entirely from the terminal.
+
+### Install
+
+```bash
+# macOS
+brew install cockroachdb/tap/ccloud
+
+# Linux
+curl https://binaries.cockroachdb.com/ccloud/ccloud_linux-amd64_0.6.12.tar.gz | tar -xz
+cp -i ccloud /usr/local/bin/
+
+# Windows: download and extract, then add to PATH
+# https://binaries.cockroachdb.com/ccloud/ccloud_windows-amd64_0.6.12.zip
+```
+
+### Authenticate and Create
+
+```bash
+# Opens a browser to log in
+ccloud auth login
+
+# On a headless server (no browser):
+ccloud auth login --no-redirect
+
+# Fastest path: interactive walkthrough of login + cluster creation + connection
+ccloud quickstart
+```
+
+Or run the steps individually:
+
+```bash
+# Create a Basic cluster (defaults: GCP, closest region, auto-generated name)
+ccloud cluster create basic
+
+# Create a Standard cluster instead (Preview plan, uses trial credits)
+ccloud cluster create standard
+
+# Create an admin SQL user (prompts for password)
+ccloud cluster user create my-app-db appuser
+
+# Open a SQL shell to the cluster
+ccloud cluster sql my-app-db
+```
+
+---
+
+## Step 4: Create Tables
+
+From the SQL shell (`ccloud cluster sql my-app-db` or the console's SQL editor):
+
+```sql
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name STRING NOT NULL,
+    email STRING UNIQUE NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE posts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title STRING NOT NULL,
+    body STRING,
+    user_id UUID REFERENCES users(id),
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+> **Tip:** Use `UUID` primary keys with `gen_random_uuid()`, not `SERIAL`. Sequential IDs concentrate writes on one node in a distributed database; random UUIDs spread the load. `STRING` is CockroachDB's alias for `TEXT` -- both work.
+
+---
+
+## Use in Node.js
+
+CockroachDB has full support for the `pg` driver, plus Prisma, Sequelize, and TypeORM. Cockroach Labs ships a dedicated Sequelize adapter with client-side transaction retry handling built in.
+
+### Install
+
+```bash
+npm install pg
+```
+
+### Connect with pg
+
+```js
+import pg from 'pg';
+const { Pool } = pg;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL, // includes sslmode=verify-full
+});
+
+// Create
+await pool.query(
+  'INSERT INTO users (name, email) VALUES ($1, $2)',
+  ['Sagar', 'sagar@example.com']
+);
+
+// Read
+const { rows } = await pool.query('SELECT * FROM users');
+console.log(rows);
+
+// Update
+await pool.query(
+  'UPDATE users SET name = $1 WHERE email = $2',
+  ['Sagar Gupta', 'sagar@example.com']
+);
+
+// Delete
+await pool.query('DELETE FROM users WHERE email = $1', ['sagar@example.com']);
+
+await pool.end();
+```
+
+### With Express.js
+
+```js
+import express from 'express';
+import pg from 'pg';
+
+const { Pool } = pg;
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const app = express();
+app.use(express.json());
+
+app.get('/api/users', async (req, res) => {
+  const { rows } = await pool.query('SELECT * FROM users ORDER BY created_at DESC');
+  res.json(rows);
+});
+
+app.post('/api/users', async (req, res) => {
+  const { name, email } = req.body;
+  const { rows } = await pool.query(
+    'INSERT INTO users (name, email) VALUES ($1, $2) RETURNING *',
+    [name, email]
+  );
+  res.status(201).json(rows[0]);
+});
+
+app.listen(process.env.PORT || 3000);
+```
+
+> **Note:** Use a persistent `Pool`, not one-off `Client` connections. Persistent pools also mitigate transient "connection refused" errors on serverless clusters.
+
+---
+
+## Use in Python
+
+CockroachDB has full support for `psycopg3` and `psycopg2`, plus SQLAlchemy and Django. The official SQLAlchemy and Django adapters include client-side transaction retry handling.
+
+### Install
+
+```bash
+pip install "psycopg[binary]"
+```
+
+### Connect with psycopg 3
+
+```python
+import os
+import psycopg
+
+DATABASE_URL = os.environ["DATABASE_URL"]
+
+with psycopg.connect(DATABASE_URL) as conn:
+    with conn.cursor() as cur:
+        # Create
+        cur.execute(
+            "INSERT INTO users (name, email) VALUES (%s, %s)",
+            ("Sagar", "sagar@example.com"),
+        )
+
+        # Read
+        cur.execute("SELECT id, name, email FROM users")
+        for row in cur.fetchall():
+            print(row)
+
+        # Update
+        cur.execute(
+            "UPDATE users SET name = %s WHERE email = %s",
+            ("Sagar Gupta", "sagar@example.com"),
+        )
+
+        # Delete
+        cur.execute("DELETE FROM users WHERE email = %s", ("sagar@example.com",))
+
+    conn.commit()
+```
+
+### With SQLAlchemy (official adapter)
+
+The `sqlalchemy-cockroachdb` adapter adds CockroachDB-specific behavior, including automatic retries for transaction contention errors:
+
+```bash
+pip install sqlalchemy sqlalchemy-cockroachdb "psycopg[binary]"
+```
+
+```python
+import os
+from sqlalchemy import create_engine, text
+
+# Swap the scheme so SQLAlchemy uses the CockroachDB dialect with psycopg 3
+DATABASE_URL = os.environ["DATABASE_URL"].replace(
+    "postgresql://", "cockroachdb+psycopg://", 1
+)
+
+engine = create_engine(DATABASE_URL)
+
+with engine.connect() as conn:
+    result = conn.execute(text("SELECT now()"))
+    print(result.fetchone())
+```
+
+### ORM Support at a Glance
+
+| Tool | Support | Retry handling included |
+|------|---------|-------------------------|
+| pg (Node.js) | Full | No (add your own) |
+| pgx (Go) | Full | No (add your own) |
+| psycopg3 / psycopg2 | Full | No (add your own) |
+| JDBC | Full | No (add your own) |
+| Prisma | Full | No (add your own) |
+| TypeORM | Full | No (add your own) |
+| Sequelize | Full | Yes (official adapter) |
+| SQLAlchemy | Full | Yes (official adapter) |
+| Django | Full | Yes (official adapter) |
+| GORM | Full | Yes (official adapter) |
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DATABASE_URL` | Full connection string from the Connect dialog | `postgresql://appuser:pass@my-app-db-1234.cockroachlabs.cloud:26257/defaultdb?sslmode=verify-full` |
+
+Set it locally:
+
+```bash
+export DATABASE_URL="postgresql://appuser:password@my-app-db-1234.cockroachlabs.cloud:26257/defaultdb?sslmode=verify-full"
+```
+
+Set it on your deployment platform:
+
+- **Render:** Service > Environment tab > Add `DATABASE_URL`
+- **Vercel:** Project Settings > Environment Variables > Add `DATABASE_URL`
+- **Railway:** Service > Variables tab > New Variable
+- **Local:** Create a `.env` file and add `.env` to `.gitignore`
+
+```bash
+# .env
+DATABASE_URL=postgresql://appuser:password@my-app-db-1234.cockroachlabs.cloud:26257/defaultdb?sslmode=verify-full
+```
+
+---
+
+## Free Tier Info
+
+Short answer to "is there still a free tier": **yes**. The old Serverless free tier (10 GiB + 50M RUs) survived the 2024 rename as the Basic plan's monthly free benefit.
+
+| Feature | Basic free allotment |
+|---------|----------------------|
+| **Monthly free credit** | $15 per organization per month |
+| **Storage included** | 10 GiB |
+| **Request Units included** | 50 million RUs |
+| **Overage: RUs** | $0.20 per 1 million RUs |
+| **Overage: storage** | $0.50 per GiB per month |
+| **Burst capacity** | Up to 30K RU/sec (~60 vCPUs) |
+| **SLA** | 99.99% |
+| **Cloud providers** | GCP or AWS (no Azure on Basic) |
+| **Regions** | Up to 6 per cluster |
+| **IP allowlist rules** | Max 50 |
+| **Trial credits** | $400 org-wide, no credit card required |
+
+### Current plans (as of 2026-07-06)
+
+| Plan | Pricing | Notes |
+|------|---------|-------|
+| **Basic** | Starts at $0/month | Bursty workloads, up to 30K RU/sec (~60 vCPUs), 99.99% SLA. Formerly "Serverless" |
+| **Standard** | 2 vCPUs start at $0.18/hr | Preview. Provisioned compute, up to 200 vCPUs |
+| **Advanced** | 4 vCPUs start at $0.60/hr | Up to 99.999% multi-region SLA. Formerly "Dedicated" |
+
+### Key things to know
+
+- **The $400 trial needs no card. The recurring $15/month free benefit does.** Trial credits apply to the first $400 in costs for all clusters in your org, regardless of plan. After the trial, the monthly $15 benefit (50M RUs + 10 GiB) kicks in only once a payment method is added -- and you are charged only for usage above it.
+- **Orgs on annual or multi-year contracts are NOT eligible** for the monthly free benefit. Pay-as-you-go only.
+- **Trial expiry is unforgiving.** If the $400 runs out (or expires) with no payment method on file, a 30-day grace period starts with throttled clusters. After that, all clusters are **deleted permanently**. Add a card before the trial ends if you have data you care about.
+- **Request Units are an abstracted compute + I/O metric.** Typical SELECTs cost 1-15 RUs; INSERTs and UPDATEs cost 10-25 RUs. 50 million RUs go a long way for a hobby app. Cockroach Labs recommends setting resource limits ~30% above expected usage.
+- **Hitting limits has two distinct failure modes.** Storage limit reached: cluster shows **THROTTLED** and refuses writes until you delete data or raise the limit. RU limit reached: cluster shows **DISABLED** until you raise the limit or the next billing cycle begins. Reads keep working while THROTTLED; nothing works while DISABLED.
+- **No version management.** Basic clusters always run the latest stable CockroachDB (v26.2, GA 2026-04-27). A new major version ships quarterly.
+- **Multi-region on the free plan is real.** A Basic cluster with two regions survives zone failures; three regions survive a full regional outage. Extra regions consume RUs and storage faster, though.
+- **Check your network defaults.** Standard clusters are created with a `0.0.0.0/0` allowlist entry (open to all traffic). Replace it with your own IP ranges in the Cloud Console under Networking. Basic and Standard support at most 50 allowlist rules.
+
+---
+
+## Custom Domain
+
+CockroachDB Cloud does not support custom domains for database connections. Use the provided `<cluster-name>.cockroachlabs.cloud` host from the Connect dialog.
+
+---
+
+## Troubleshooting
+
+### Problem: `Error: x509: certificate signed by unknown authority`
+
+**Cause:** The client cannot verify the cluster's CA certificate. Common when a machine's trust store is stripped down, or when mixing Basic/Standard connections with self-hosted certificate setups.
+
+**Fix:**
+
+1. Download the cluster CA certificate -- the Connect dialog gives an OS-specific command that drops it into the default PostgreSQL certificate directory. Copy the exact command from the dialog; it follows this pattern:
+
+```bash
+curl --create-dirs -o "$HOME/.postgresql/root.crt" \
+  'https://cockroachlabs.cloud/clusters/<cluster-id>/cert'
+```
+
+2. Point `sslrootcert` at it in the connection string:
+
+```
+postgresql://appuser:password@my-app-db-1234.cockroachlabs.cloud:26257/defaultdb?sslmode=verify-full&sslrootcert=$HOME/.postgresql/root.crt
+```
+
+3. For workload and benchmarking tools, switching to `sslmode=require` instead of `sslmode=verify-full` also resolves it (weaker verification -- fine for testing, not production).
+
+### Problem: `dial tcp 35.196.33.161:26257: i/o timeout`
+
+**Cause:** Your network is not authorized to reach the cluster -- missing IP allowlist entry, no internet access, or a firewall blocking port 26257.
+
+**Fix:**
+
+1. In the Cloud Console, go to your cluster > **Networking** and add your IP to the allowlist
+2. Confirm outbound traffic on port 26257 is allowed by your firewall (corporate networks often block non-standard ports)
+3. Increase your application's connection timeout values -- cross-region round trips can exceed aggressive defaults
+
+### Problem: `FATAL: CodeParamsRoutingFailed: rejected by BackendConfigFromParams: Invalid cluster name`
+
+**Cause:** The routing prefix (cluster name) in the connection string is wrong, so the shared serverless gateway cannot route your connection to a cluster.
+
+**Fix:** Verify the cluster name and database name under **Cluster Overview** > **Connect** in the Cloud Console, and paste the connection string fresh from the dialog rather than hand-assembling it.
+
+### Problem: `dial tcp: lookup gcp-us-east4.crdb.io: no such host`
+
+**Cause:** DNS lookup failed because the hostname in the connection string is wrong (typo, stale host from an old cluster, or a copy-paste from a different environment).
+
+**Fix:**
+
+1. Verify the host in the Cloud Console under **Connect** > **Connection parameters**
+2. If you see intermittent `connection refused` errors alongside DNS issues, switch to a persistent connection pool instead of opening a new connection per query
+
+### Problem: `restart transaction` errors (SQLSTATE 40001)
+
+**Cause:** Transaction contention. CockroachDB aborts one of two conflicting transactions and asks the client to retry -- this is normal distributed-database behavior under concurrent writes, not a bug.
+
+**Fix:**
+
+1. Implement client-side retry handling. Minimal Node.js pattern:
+
+```js
+async function withRetry(fn, maxRetries = 3) {
+  for (let i = 0; i <= maxRetries; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (err.code !== '40001' || i === maxRetries) throw err;
+      await new Promise((r) => setTimeout(r, 2 ** i * 100)); // backoff
+    }
+  }
+}
+
+await withRetry(() => pool.query('UPDATE users SET name = $1 WHERE id = $2', [name, id]));
+```
+
+2. Or use an official adapter that retries for you: the Sequelize, SQLAlchemy, Django, and GORM adapters all ship with built-in retry handling
+3. Reduce contention: keep transactions short, avoid hot rows, batch writes where possible
+
+### Problem: `cannot load certificates. Check your certificate settings, set --certs-dir, or use --insecure`
+
+**Cause:** An outdated `cockroach` client binary that cannot connect to Cloud clusters without explicit CA certificate paths.
+
+**Fix:** Upgrade the client to v21.2.5 or later (current is v26.2), which connects to Cloud clusters without specifying certificate paths:
+
+```bash
+# macOS
+brew update && brew upgrade cockroach
+
+# Verify
+cockroach version
+```

--- a/guides/coolify.md
+++ b/guides/coolify.md
@@ -1,0 +1,357 @@
+# Coolify
+
+> Self-host an open-source Heroku/Vercel alternative on your own server: push-to-deploy from GitHub, one-click databases, and automatic HTTPS with zero platform fees.
+
+Coolify is an open-source, self-hostable PaaS that turns any VPS into a push-to-deploy platform. The current stable release is v4.1.2 (published 2026-06-04); v4.0.0 (2026-04-27) ended the long v4.0.0-beta series, and v4.1.0 (2026-05-18) added a Railpack build pack in beta. You bring the server (Hetzner, DigitalOcean, EC2, even a Raspberry Pi), and Coolify handles builds, deployments, reverse proxying via Traefik or Caddy, and Let's Encrypt certificates. Self-hosted Coolify is free forever with full access to all features.
+
+## Prerequisites
+
+- [ ] A Linux server or VPS with root SSH access ([Hetzner](https://www.hetzner.com/cloud), [DigitalOcean](https://www.digitalocean.com/), [AWS EC2](https://aws.amazon.com/ec2/), or a Raspberry Pi with a 64-bit OS)
+- [ ] Minimum 2 CPU cores, 2 GB RAM, 30 GB free storage
+- [ ] A supported OS: Ubuntu LTS (20.04/22.04/24.04) is the easiest path; Debian-based, Red Hat-based (CentOS/Fedora/AlmaLinux/Rocky), SUSE-based, Arch, Alpine, and Raspberry Pi OS 64-bit also work (AMD64 or ARM64)
+- [ ] A [GitHub account](https://github.com/) for repo-based deployments
+- [ ] (Optional) A domain you control, for custom domains and wildcard subdomains
+
+> **Note:** Coolify requires Docker Engine 24+ on the server. Snap-installed Docker is not supported -- remove it first if present. Non-LTS Ubuntu versions require [manual installation](https://coolify.io/docs/get-started/installation).
+
+---
+
+## Step 1: Install Coolify
+
+SSH into your server and run the official install script as root:
+
+```bash
+ssh root@YOUR_SERVER_IP
+
+curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash
+```
+
+The script sets up Coolify and stores all its data under `/data/coolify`.
+
+To pre-create the admin account non-interactively (useful for scripted provisioning), pass env vars to the installer:
+
+```bash
+curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo env \
+  ROOT_USERNAME=admin \
+  ROOT_USER_EMAIL=you@example.com \
+  ROOT_USER_PASSWORD='use-a-long-random-password' \
+  bash
+```
+
+To pin a specific version instead of the latest:
+
+```bash
+curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash -s 4.1.2
+```
+
+## Step 2: Create the Admin Account
+
+Open the dashboard in your browser:
+
+```
+http://YOUR_SERVER_IP:8000
+```
+
+**Create the admin account immediately.** Registration stays open until the first account exists -- anyone who reaches port 8000 before you register can take over the instance. If you passed `ROOT_USERNAME` / `ROOT_USER_EMAIL` / `ROOT_USER_PASSWORD` to the installer, the account already exists and you can just log in.
+
+## Step 3: Open Firewall Ports
+
+A self-hosted Coolify instance needs these inbound ports:
+
+| Port | Purpose |
+|------|---------|
+| 22 | SSH (or your custom SSH port) |
+| 80 | HTTP + Let's Encrypt HTTP-01 validation |
+| 443 | HTTPS |
+| 8000 | Coolify dashboard (HTTP) |
+| 6001 | Realtime / websockets |
+| 6002 | Web terminal (since v4.0.0-beta.336) |
+
+Example with UFW:
+
+```bash
+sudo ufw allow 22/tcp
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw allow 8000/tcp
+sudo ufw allow 6001/tcp
+sudo ufw allow 6002/tcp
+sudo ufw enable
+```
+
+> **Gotcha:** Docker inserts NAT-based iptables rules that bypass UFW entirely, so UFW rules alone will not block ports published by containers. Prefer your cloud provider's firewall dashboard (Hetzner Cloud Firewall, AWS security groups, DO Cloud Firewalls), or use the community [ufw-docker](https://github.com/chaifeng/ufw-docker) tool if you must stay on UFW.
+
+Once you put the dashboard behind a custom domain (see [Custom Domain](#custom-domain)), you can safely close 8000, 6001, and 6002. Servers managed by Coolify Cloud only need 22, 80, and 443.
+
+## Step 4: Deploy a Public GitHub Repo
+
+1. In the dashboard, open (or create) a **Project**
+2. Click **+ New** to add a resource
+3. Choose **Public Repository**
+4. Select the server to deploy on (**localhost** is auto-selected if you have no remote servers)
+5. Paste the repository URL, e.g. `https://github.com/<username>/my-app`
+   - Paste a `/tree/branch-name` URL to auto-detect a specific branch
+6. Click **Check Repository**
+7. Configure the **Build Pack** (Nixpacks, Static, Dockerfile, Docker Compose) and the **Port** your app listens on
+8. Deploy
+
+Until you configure a custom or wildcard domain, Coolify generates a default URL for the app via [sslip.io](https://sslip.io/) based on the server IP, e.g. `http://<random-subdomain>.203.0.113.1.sslip.io` (IPv6 colons become dashes).
+
+## Step 5: Deploy a Private Repo (GitHub App)
+
+The GitHub App integration is the recommended way to deploy private repos -- it also enables push-to-deploy webhooks and pull-request preview deployments automatically.
+
+### Create the GitHub App source
+
+1. In the sidebar, go to **Sources** and click **+ Add**
+2. Enter a name for the app and your GitHub organization (leave blank for a personal account)
+3. Click **Continue**
+4. Pick the webhook endpoint -- this should be your Coolify dashboard URL, so it must be reachable from the internet
+5. Click **Register now**
+6. On GitHub: name the app, click **Create app**
+7. Back in Coolify, click **Install repositories on Github** and select which repositories the app can access
+
+### Deploy from the private repo
+
+1. In your project, click **+ New**
+2. Choose **Private Repository (with Github App)**
+3. Pick the GitHub App you just created
+4. Choose the repository and click **Load Repository**
+5. Configure the Build Pack and Port
+6. Deploy
+
+> **Note:** There is also a manual GitHub App setup if the guided flow does not fit -- it requires the App ID, Client Secret, Private Key, and Installation ID from GitHub. Deploy keys are a simpler read-only alternative for private repos, but they do not give you webhooks or PR previews.
+
+## Step 6: Enable Auto-Deploy on Push
+
+**With a GitHub App source:** auto-deploy is enabled automatically. Push to the configured branch and Coolify redeploys. PR preview deployments are also on by default (you can disable them when registering the app).
+
+**For public repos without the App**, wire up a manual webhook:
+
+1. In the application's **Advanced** settings, enable the **Auto Deploy** toggle
+2. Generate a webhook secret in Coolify and copy the webhook URL
+3. On GitHub: repository **Settings** > **Webhooks** > **Add webhook**
+4. Paste the Coolify webhook URL, set the secret, and trigger on **push** events
+
+GitHub Actions is the third supported CI/CD method if you want to build externally and tell Coolify when to deploy.
+
+> **Important:** TCP 80/443 must be open on the Coolify server, otherwise GitHub's webhooks can never reach the instance and pushes will silently not deploy.
+
+---
+
+## Built-in Databases
+
+Coolify ships 8 one-click databases: **PostgreSQL, MySQL, MariaDB, MongoDB, Redis, DragonFly, KeyDB, and ClickHouse**. Add one from a project with **+ New**, same as an application.
+
+Databases are private to the server's Docker network by default. Two ways to expose one publicly:
+
+1. **Port mapping** -- classic Docker host-port mapping. Simple, but changing it requires a database restart.
+2. **Public Port** -- routes through an Nginx TCP proxy. No restart needed to change; the proxy has a default timeout of 3600 seconds, adjustable in the database settings.
+
+> **Note:** For databases moving large files (big dumps, media blobs), disable "Make it publicly available?" (the Nginx TCP proxy) and use a direct port mapping instead -- long transfers can hit the proxy timeout.
+
+---
+
+## Upgrading Coolify
+
+Three options, from most to least hands-off:
+
+1. **Automatic** -- Coolify checks for and installs updates by itself. On by default; disable it in **Settings** if you want control.
+2. **Semi-automatic** -- when an update is available, an **Upgrade** button appears in the sidebar. Click it when convenient.
+3. **Manual** -- re-run the install script:
+
+```bash
+curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash
+
+# Or pin a target version
+curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash -s 4.1.2
+```
+
+---
+
+## Environment Variables
+
+The install script accepts these optional variables (pass them with `sudo env` as shown in Step 1):
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `ROOT_USERNAME` | Pre-create the admin account: username | `admin` |
+| `ROOT_USER_EMAIL` | Pre-create the admin account: email | `you@example.com` |
+| `ROOT_USER_PASSWORD` | Pre-create the admin account: password | `use-a-long-random-password` |
+| `DOCKER_ADDRESS_POOL_BASE` | Docker address pool base (default `10.0.0.0/8`) | `172.16.0.0/12` |
+| `DOCKER_ADDRESS_POOL_SIZE` | Docker address pool subnet size (default `24`) | `24` |
+
+Coolify's own instance configuration lives on the server at:
+
+```bash
+/data/coolify/source/.env
+```
+
+Everything else Coolify manages (proxy config, certificates, application data) lives under `/data/coolify`. Back that directory up.
+
+---
+
+## Custom Domain
+
+### App domain with automatic HTTPS
+
+1. Point an **A record** for your domain at the server IP:
+
+   | Type | Name | Value |
+   |------|------|-------|
+   | A | `app` (or `@`) | `YOUR_SERVER_IP` |
+
+2. In the application's settings, enter the domain **with the `https://` scheme** in the **Domains** (FQDN) field:
+
+   ```
+   https://app.example.com
+   ```
+
+3. Redeploy. Coolify configures the proxy (Traefik or Caddy), issues a Let's Encrypt certificate, and renews it automatically before the 90-day expiry. No manual certbot, no cron jobs.
+
+Multiple domains are comma-separated, and custom ports are allowed:
+
+```
+https://example.com:8080,http://api.example.com:3000
+```
+
+If certificate issuance fails, the proxy serves a self-signed certificate as a fallback -- see [Troubleshooting](#troubleshooting) for the usual causes.
+
+### Wildcard subdomains
+
+1. Add an A record for `*.example.com` pointing at the server IP
+2. In **Server** settings, set the **Wildcard Domain** field to your domain
+
+Coolify then autogenerates subdomains like `random.example.com` for every new resource instead of the default sslip.io URLs. Note that wildcard **SSL** certificates additionally need a DNS-01 challenge (see Troubleshooting).
+
+### Dashboard domain
+
+Give the Coolify instance itself a domain on the `/settings` page of your dashboard. Once that works over HTTPS, close ports 8000, 6001, and 6002 in your firewall.
+
+> **Gotcha:** Domains with special characters (e.g. German umlaut domains) must be entered in punycode form (`xn--mnchen-3ya.example.com`). Coolify does not auto-convert.
+
+---
+
+## Free Tier Info
+
+Self-hosted Coolify is the whole product, free: "Full access to all features. No limitation or restrictions." Coolify Cloud is the same open-source codebase with a managed control plane -- no locked-behind-paywall features.
+
+| Feature | Self-Hosted | Coolify Cloud |
+|---------|-------------|---------------|
+| **Price** | Free forever | $5/month base |
+| **Connected servers** | Unlimited (your hardware) | 2 included, $3/month per additional server |
+| **Deployments** | Unlimited | Unlimited per server |
+| **Feature set** | Everything | Everything (same codebase) |
+| **Coolify upgrades** | You run them | Zero-maintenance, staged updates |
+| **Control plane backups** | Your responsibility | Daily database backups |
+| **Email notifications** | Bring your own SMTP | Preconfigured |
+| **Annual billing** | n/a | 20% savings |
+
+Key details:
+
+- **Coolify Cloud does not host your apps.** You still bring your own servers (Hetzner, DigitalOcean, EC2, Raspberry Pi, etc.); the Cloud plan only hosts and maintains the Coolify control plane for you.
+- The realistic total cost of self-hosting is just your VPS. A 2-core/2 GB box from a budget provider comfortably runs Coolify plus a few small apps.
+- Cloud-managed servers only need ports 22, 80, and 443 open -- the dashboard ports stay closed because the dashboard is hosted for you.
+
+---
+
+## Troubleshooting
+
+### Problem: 502 Bad Gateway when opening the app
+
+**Cause:** The proxy cannot reach your app. Usually the **Port Exposes** value is wrong, a leftover host port mapping is blocking proxy routing, or the app listens on `localhost` instead of `0.0.0.0`.
+
+**Fix:**
+
+1. Set the correct port in **Port Exposes** (the port your app actually listens on) and restart the app
+2. Delete any host port mappings you added -- the proxy talks to the container directly
+3. Make the app bind `0.0.0.0`:
+
+```js
+// Node.js
+app.listen(process.env.PORT || 3000, '0.0.0.0');
+```
+
+```python
+# FastAPI / uvicorn
+# uvicorn main:app --host 0.0.0.0 --port 3000
+```
+
+### Problem: Let's Encrypt not working, browser shows a self-signed certificate
+
+**Cause:** Certificate issuance failed, so the proxy fell back to its self-signed cert. Common causes: port 80 not reachable from the internet (HTTP-01 validation needs it), Cloudflare's orange-cloud proxy intercepting validation, an IPv4/IPv6 mismatch (a closed port on either protocol breaks validation), Let's Encrypt rate limiting (429), or WAF blocks (403).
+
+**Fix:**
+
+1. Open port 80 and confirm it is reachable from outside
+2. If the domain is behind Cloudflare, grey-cloud it (DNS only) until the cert is issued
+3. If IPv6 is unused on the server, remove the domain's AAAA records
+4. Force regeneration:
+
+```bash
+sudo rm /data/coolify/proxy/acme.json
+# then restart the Coolify proxy from the dashboard
+```
+
+### Problem: Proxy log says "Cert resolver doesn't exist letsencrypt"
+
+**Cause:** On non-root installs, `/data/coolify/proxy/acme.json` ends up with wrong permissions, and Traefik refuses to use overly permissive files.
+
+**Fix:**
+
+```bash
+sudo chmod 600 /data/coolify/proxy/acme.json
+```
+
+### Problem: Wildcard SSL certificate is not issued
+
+**Cause:** HTTP-01 challenges cannot validate wildcard certificates. Wildcards require a DNS-01 challenge, which needs API access to your DNS provider.
+
+**Fix:**
+
+1. Configure the DNS provider and its API keys for the DNS challenge in the proxy settings
+2. If you are using custom certificates instead: files must use `.cert`/`.key` extensions (rename `.pem`) and live in `/data/coolify/proxy/certs`
+3. After any certificate change, delete `acme.json` and restart the proxy:
+
+```bash
+sudo rm /data/coolify/proxy/acme.json
+# then restart the Coolify proxy from the dashboard
+```
+
+### Problem: 504 Gateway Timeout on large uploads or slow endpoints
+
+**Cause:** Either a custom Docker network is isolating the app from the proxy, or the default 60-second read timeout in Traefik/Nginx kills long requests.
+
+**Fix:**
+
+1. Drop custom Docker networks -- use Coolify **Destinations** instead so the proxy and app share a network
+2. For Traefik, raise the timeouts in the server proxy settings:
+
+```
+--entrypoints.https.transport.respondingTimeouts.readTimeout=5m
+--entrypoints.https.transport.respondingTimeouts.writeTimeout=5m
+--entrypoints.https.transport.respondingTimeouts.idleTimeout=5m
+```
+
+3. For Caddy, add a container label:
+
+```
+caddy.servers.timeouts.read_body=300s
+```
+
+### Problem: Server crashes or becomes unresponsive during builds
+
+**Cause:** Docker image builds are resource-hungry and overload small servers (remember the 2-core/2 GB minimum is a minimum).
+
+**Fix:**
+
+1. SSH in and check what is eating the box:
+
+```bash
+htop
+```
+
+2. Kill the heavy build process, then pick a longer-term fix:
+   - Upgrade the server
+   - Build images externally in GitHub Actions and deploy the pre-built image
+   - Use Coolify's dedicated **Build Server** feature to move builds off the app server

--- a/guides/digitalocean.md
+++ b/guides/digitalocean.md
@@ -8,7 +8,7 @@ DigitalOcean App Platform is a Platform-as-a-Service that builds and deploys you
 
 - [ ] A [DigitalOcean account](https://cloud.digitalocean.com/registrations/new) (new accounts get $200 free credit for 60 days)
 - [ ] [Git](https://git-scm.com/downloads) installed locally
-- [ ] [Node.js 18+](https://nodejs.org/) or [Python 3.9+](https://www.python.org/downloads/) depending on your stack
+- [ ] [Node.js 22+](https://nodejs.org/) or [Python 3.12+](https://www.python.org/downloads/) depending on your stack
 - [ ] (Optional) [doctl CLI](https://docs.digitalocean.com/reference/doctl/how-to/install/) for command-line management
 - [ ] (Optional) [Docker](https://docs.docker.com/get-docker/) for container-based deployments
 
@@ -19,10 +19,10 @@ DigitalOcean App Platform is a Platform-as-a-Service that builds and deploys you
 brew install doctl
 
 # Ubuntu/Debian
-snap install doctl
+sudo snap install doctl
 
-# Windows (scoop)
-scoop install doctl
+# Windows: download the release archive from GitHub
+# https://github.com/digitalocean/doctl/releases
 
 # Authenticate
 doctl auth init
@@ -69,13 +69,13 @@ Create `package.json`:
   "name": "my-do-app",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.0"
+    "express": "^5.2.0"
   }
 }
 ```
@@ -100,7 +100,7 @@ git push -u origin main
 5. App Platform auto-detects Node.js and configures:
    - **Build Command:** `npm install`
    - **Run Command:** `npm start`
-6. Choose a plan (Starter at $5/mo or Basic at $7/mo)
+6. Pick an instance size in the resource settings (the smallest container is 1 shared vCPU / 512 MiB at $5/mo)
 7. Click **Create Resources**
 
 Your app is live in a few minutes at `https://your-app-xxxxx.ondigitalocean.app`.
@@ -148,8 +148,8 @@ def health_check():
 Create `requirements.txt`:
 
 ```
-fastapi==0.109.0
-uvicorn[standard]==0.27.0
+fastapi==0.139.0
+uvicorn[standard]==0.50.1
 ```
 
 ### Step 2: Push to GitHub and Deploy
@@ -259,9 +259,8 @@ static_sites:
 databases:
   - name: db
     engine: PG
-    version: "16"
-    size: db-s-dev-database
-    num_nodes: 1
+    version: "18"
+    production: false
 ```
 
 Deploy with doctl:
@@ -341,21 +340,21 @@ DigitalOcean offers managed databases that integrate directly with App Platform.
 
 1. Go to your app **Settings**
 2. Click **Add Resource** > **Database**
-3. Choose engine (PostgreSQL, MySQL, or Redis)
-4. Select a plan:
-   - **Dev Database:** $0 (shared, 1 GB, no standby -- good for development)
-   - **Production (Basic):** from $15/month (dedicated resources)
+3. Choose the database type:
+   - **Dev Database:** $7/mo (PostgreSQL only, 512 MiB, no standby -- good for development)
+   - **Production:** attach an existing managed cluster (PostgreSQL or MySQL from $15.15/mo)
 
 ### Add via app.yaml
 
 ```yaml
 databases:
   - name: db
-    engine: PG          # PG, MYSQL, or REDIS
-    version: "16"
-    size: db-s-dev-database    # Dev (free with app)
-    num_nodes: 1
+    engine: PG          # dev databases are PostgreSQL only
+    version: "18"
+    production: false   # dev database ($7/mo, auto-provisioned)
 ```
+
+For a production database, set `production: true` and point `cluster_name` at an existing managed cluster.
 
 ### Connect from Your App
 
@@ -444,14 +443,19 @@ doctl compute domain records create yourdomain.com \
 
 ## Pricing
 
-### App Platform Plans
+### App Platform Instance Sizes
 
-| Plan | vCPU | Memory | Price | Notes |
-|------|------|--------|-------|-------|
-| **Starter** | Shared | 512 MB | $5/mo | Basic apps, sleeps on inactivity |
-| **Basic** | 1 | 512 MB | $7/mo | Always-on, auto-deploy |
-| **Basic** | 1 | 1 GB | $12/mo | More memory |
-| **Professional** | 1 | 1 GB | $25/mo | Horizontal scaling, alerts |
+App Platform no longer uses Starter/Basic/Professional plan tiers -- you pay per container instance size. All instances are always-on (no sleep on inactivity). Common shared-CPU sizes:
+
+| Instance Slug | vCPU | Memory | Transfer | Price |
+|---------------|------|--------|----------|-------|
+| `apps-s-1vcpu-0.5gb` | 1 (shared) | 512 MiB | 50 GiB | $5/mo |
+| `apps-s-1vcpu-1gb-fixed` | 1 (shared) | 1 GiB | 100 GiB | $10/mo |
+| `apps-s-1vcpu-1gb` | 1 (shared) | 1 GiB | 150 GiB | $12/mo |
+| `apps-s-1vcpu-2gb` | 1 (shared) | 2 GiB | 200 GiB | $25/mo |
+| `apps-s-2vcpu-4gb` | 2 (shared) | 4 GiB | 250 GiB | $50/mo |
+
+Dedicated-CPU instances range from $29/mo to $392/mo.
 
 ### Free Credit
 
@@ -459,15 +463,17 @@ New DigitalOcean accounts receive **$200 in free credit** valid for 60 days. Thi
 
 ### Static Sites
 
-Static sites on App Platform have a free tier: 3 static sites, 1 GB bandwidth/month.
+Static sites on App Platform have a free tier: up to 3 static-site apps free (1 GiB transfer each). Additional static-site apps cost $3/mo.
 
 ### Managed Database Pricing
 
-| Engine | Dev (shared) | Basic (1 node) |
-|--------|-------------|----------------|
-| PostgreSQL | Free with app | from $15/mo |
-| MySQL | Free with app | from $15/mo |
-| Redis | Free with app | from $15/mo |
+| Engine | Dev (in-app) | Managed cluster (1 node) |
+|--------|-------------|--------------------------|
+| PostgreSQL | $7/mo (512 MiB) | from $15.15/mo |
+| MySQL | Not available as dev database | from $15.15/mo |
+| Valkey (Redis-compatible caching) | Not available as dev database | from $15/mo |
+
+DigitalOcean replaced Managed Redis with **Managed Caching for Valkey** (Redis-compatible). Dev databases attached to an app are PostgreSQL only.
 
 ---
 
@@ -495,7 +501,7 @@ DROPLET_IP=$(doctl compute droplet get my-server --format PublicIPv4 --no-header
 ssh root@$DROPLET_IP
 
 # On the Droplet: install Node.js
-curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 apt-get install -y nodejs
 
 # Clone your app
@@ -565,7 +571,7 @@ git commit -m "Fix dependencies"
 git push
 
 # Specify Node.js version in package.json
-# "engines": { "node": ">=18" }
+# "engines": { "node": ">=22" }
 
 # Python: ensure requirements.txt is accurate
 pip freeze > requirements.txt
@@ -578,13 +584,13 @@ Check the build logs in the DigitalOcean dashboard: **App** > **Deployments** > 
 
 ### Problem: App exceeds resource limits (OOM killed)
 
-**Cause:** The application uses more memory than the plan allows.
+**Cause:** The application uses more memory than the instance size allows.
 
 **Fix:**
 
 1. Check resource usage in the **Insights** tab of your app
 2. Upgrade to a larger instance size:
-   - Dashboard: **Settings** > **Edit Plan**
+   - Dashboard: **Settings** > select the component > edit the instance size
    - Or update `instance_size_slug` in `app.yaml`
 3. Optimize your application's memory usage (connection pooling, streaming large files, etc.)
 

--- a/guides/dns-domains.md
+++ b/guides/dns-domains.md
@@ -27,7 +27,7 @@ The Domain Name System (DNS) translates human-readable domain names (e.g., `myap
 |--------|---------|---------------|
 | **A** | Maps a domain to an IPv4 address | `185.199.108.153` |
 | **AAAA** | Maps a domain to an IPv6 address | `2606:50c0:8000::153` |
-| **CNAME** | Creates an alias pointing one domain to another | `cname.vercel-dns.com` |
+| **CNAME** | Creates an alias pointing one domain to another | `your-site.netlify.app` |
 | **MX** | Directs email to a mail server | `mail.example.com` (priority 10) |
 | **TXT** | Stores arbitrary text (SPF, DKIM, domain verification) | `v=spf1 include:_spf.google.com ~all` |
 | **NS** | Delegates a domain to specific name servers | `ns1.cloudflare.com` |
@@ -45,8 +45,8 @@ The Domain Name System (DNS) translates human-readable domain names (e.g., `myap
 | Registrar | Notes |
 |-----------|-------|
 | **Cloudflare Registrar** | At-cost pricing, integrated DNS and CDN, free SSL proxy, CNAME flattening for apex domains. Highly recommended if you use Cloudflare for DNS. |
-| **Namecheap** | Affordable, good UI, free WhoisGuard privacy. Popular with developers. |
-| **Google Domains** | Clean interface, integrated with Google Workspace. Transferred to Squarespace in 2023 but still operates similarly. |
+| **Namecheap** | Affordable, good UI, free Domain Privacy (formerly WhoisGuard). Popular with developers. |
+| **Squarespace Domains** | Absorbed Google Domains (acquired September 2023, all domains migrated by July 2024 -- Google Domains no longer operates). Clean interface. |
 | **GoDaddy** | Largest registrar. Functional but UI can be cluttered with upsells. |
 | **Porkbun** | Low prices, clean interface, growing in popularity among developers. |
 
@@ -77,29 +77,39 @@ GitHub Pages uses four A records for the apex domain and a CNAME for `www`.
 
 Then add your domain in the repository settings under **Pages > Custom domain**. GitHub will automatically provision a Let's Encrypt SSL certificate (may take up to 24 hours).
 
+**Tips:**
+- If your site has a build step (e.g. a framework static export to `out/` or `dist/`), the build does not emit the `CNAME` file -- copy it into the artifact in your deploy workflow (`cp public/CNAME out/CNAME`), or the site reverts to the default `*.github.io` URL on every deploy. Plain no-build repos just keep `CNAME` at the repo root.
+- When migrating a domain from GitHub Pages to another platform, remove all four `185.199.x` A records, not just one, before adding the new platform's records.
+
 ---
 
 ### Vercel
 
-Vercel uses a single CNAME record. For apex domains, Vercel supports A records as well.
+Vercel assigns unique DNS values per project -- there is no longer a universal A record IP or CNAME target. Copy the exact values shown in **Project Settings > Domains** after adding your domain.
 
 **Subdomain or www (`www.example.com`):**
 
 | Type | Name | Value |
 |------|------|-------|
-| CNAME | `www` | `cname.vercel-dns.com` |
+| CNAME | `www` | Unique per project, e.g. `d1d4fc829fe7bc7c.vercel-dns-017.com.` |
 
 **Apex domain (`example.com`):**
 
 | Type | Name | Value |
 |------|------|-------|
-| A | `@` | `76.76.21.21` |
+| A | `@` | IP shown in your dashboard (selected from an Anycast pool per plan and project) |
+
+Notes:
+- The CNAME value includes a trailing period -- copy it exactly as shown.
+- Vercel does not support IPv6, so do not add AAAA records.
 
 Add the domain via the Vercel dashboard (Project Settings > Domains) or CLI:
 
 ```bash
-vercel domains add example.com
+vercel domains add example.com my-project
 ```
+
+Without the project argument, the domain is only added to your account/team scope and is not attached to any project.
 
 SSL is provisioned automatically within minutes.
 
@@ -113,7 +123,15 @@ Render uses a CNAME pointing to your service's `.onrender.com` subdomain.
 |------|------|-------|
 | CNAME | `www` | `your-service.onrender.com` |
 
-For apex domains, Render provides specific instructions depending on your DNS provider. If your provider supports CNAME flattening (e.g., Cloudflare), you can CNAME the apex directly.
+**Apex domain (`example.com`):**
+
+| Type | Name | Value |
+|------|------|-------|
+| A | `@` | `216.24.57.1` |
+
+Point the apex at Render's anycast load balancer IP `216.24.57.1` via an A record. If your DNS provider supports ANAME/ALIAS records (or CNAME flattening, e.g. Cloudflare), you can alias the apex to your `.onrender.com` subdomain instead.
+
+Remove any AAAA records from your domain while configuring DNS -- Render is IPv4-only.
 
 Add the domain in your Render service's **Settings > Custom Domains** section. SSL certificates are provisioned automatically via Let's Encrypt.
 
@@ -131,20 +149,16 @@ Netlify supports both CNAME records and their special NETLIFY record type.
 
 **Option 2 - Netlify DNS (recommended for apex):**
 
-If you use Netlify as your DNS provider, they handle apex domains automatically with their `NETLIFY` record type. Point your nameservers to Netlify:
+If you use Netlify as your DNS provider, they handle apex domains automatically with their `NETLIFY` record type. Point your nameservers to Netlify. The name servers vary per domain (format `dns1.pXX.nsone.net`) -- copy the four values shown in the Netlify dashboard under **DNS > your domain > Name servers**.
 
-```
-dns1.p05.nsone.net
-dns2.p05.nsone.net
-dns3.p05.nsone.net
-dns4.p05.nsone.net
-```
+**Option 3 - ALIAS or A record for apex (external DNS):**
 
-**Option 3 - A record for apex:**
+Netlify recommends an ALIAS (flattened CNAME) record pointing to `apex-loadbalancer.netlify.com` if your DNS provider supports it. If not, fall back to an A record:
 
 | Type | Name | Value |
 |------|------|-------|
-| A | `@` | `75.2.60.5` |
+| ALIAS | `@` | `apex-loadbalancer.netlify.com` |
+| A (fallback) | `@` | `75.2.60.5` |
 
 SSL is automatic via Let's Encrypt.
 
@@ -152,15 +166,16 @@ SSL is automatic via Let's Encrypt.
 
 ### Railway
 
-Railway uses a CNAME record.
+Railway requires two DNS records per custom domain: a CNAME and a TXT record for domain-ownership verification. The domain will not verify with only the CNAME in place (requests 404 without the TXT record).
 
 | Type | Name | Value |
 |------|------|-------|
-| CNAME | `www` | Provided in Railway dashboard |
+| CNAME | `www` | Provided in Railway dashboard, format `[random].up.railway.app` (e.g. `g05ns7.up.railway.app`) |
+| TXT | Provided in dashboard | Provided in dashboard (ownership verification) |
 
-Add your custom domain in the Railway service settings. Railway generates a unique CNAME target for each service. SSL is automatic.
+Add your custom domain under **Service > Settings > Public Networking > + Custom Domain**. Railway generates a unique CNAME target for each service. SSL is automatic.
 
-For apex domains, use a DNS provider that supports CNAME flattening, or add an A record if Railway provides one in the dashboard.
+Railway does not provide A records for apex domains. Use a DNS provider with CNAME flattening (Cloudflare), dynamic ALIAS records (DNSimple, bunny.net), or switch your nameservers to Cloudflare.
 
 ---
 
@@ -190,7 +205,8 @@ Add the domain and request a certificate:
 
 ```bash
 fly certs add example.com
-fly certs show example.com   # check certificate status
+fly certs check example.com   # show certificate and DNS status
+fly certs list                # list all certificates
 ```
 
 ---
@@ -199,9 +215,11 @@ fly certs show example.com   # check certificate status
 
 If your domain already uses Cloudflare DNS, the setup is nearly automatic.
 
-1. Go to **Cloudflare Pages > your project > Custom domains**.
+1. Go to **Workers & Pages** in the Cloudflare dashboard, select your Pages project, then **Custom domains > Set up a domain**.
 2. Add your domain (apex or subdomain).
-3. Cloudflare automatically creates the DNS record for you.
+3. Cloudflare automatically creates the CNAME record for you.
+
+Do not add the CNAME record manually before associating the domain in the Pages dashboard -- doing so causes a 522 error.
 
 If your domain is NOT on Cloudflare DNS, you can still add a CNAME:
 
@@ -261,10 +279,10 @@ admin.example.com    -> Admin dashboard (Vercel or Railway)
 Each subdomain gets its own DNS record pointing to the appropriate platform:
 
 ```
-app     CNAME   cname.vercel-dns.com
+app     CNAME   <value from Vercel Project Settings > Domains>
 api     CNAME   api-service.onrender.com
 docs    CNAME   username.github.io
-staging CNAME   staging-app.railway.app
+staging CNAME   g05ns7.up.railway.app
 ```
 
 **CORS considerations:** When your frontend (`app.example.com`) calls your API (`api.example.com`), you need to configure CORS headers on the API:
@@ -331,7 +349,7 @@ nslookup -type=CNAME www.example.com
    ipconfig /flushdns
 
    # Linux (systemd-resolved)
-   sudo systemd-resolve --flush-caches
+   sudo resolvectl flush-caches
    ```
 
 ---
@@ -385,7 +403,7 @@ nslookup -type=CNAME www.example.com
 
 **Fixes:**
 1. Ensure you added the records to the correct domain/subdomain.
-2. Check for typos in CNAME targets (e.g., `cname.vercel-dns.com` not `cname.vercel-dns.com.` with trailing dot, though some providers add this automatically).
+2. Check for typos in CNAME targets. Copy values exactly as the platform dashboard shows them -- Vercel's per-project CNAME values include a trailing period that must be kept.
 3. Some platforms require a TXT record for verification. Check their docs.
 4. If using Cloudflare proxy (orange cloud), temporarily switch to DNS-only (grey cloud) during initial setup, then re-enable proxy after verification.
 
@@ -396,9 +414,9 @@ nslookup -type=CNAME www.example.com
 | Platform | Apex Domain | www / Subdomain | Auto SSL | Dashboard Path |
 |----------|-------------|-----------------|----------|----------------|
 | GitHub Pages | 4 A records | CNAME to `user.github.io` | Yes (Let's Encrypt) | Repo Settings > Pages |
-| Vercel | A to `76.76.21.21` | CNAME to `cname.vercel-dns.com` | Yes | Project > Settings > Domains |
-| Render | Provider-dependent | CNAME to `service.onrender.com` | Yes | Service > Settings > Custom Domains |
-| Netlify | A to `75.2.60.5` or Netlify DNS | CNAME to `site.netlify.app` | Yes | Site > Domain management |
-| Railway | CNAME flattening | CNAME (from dashboard) | Yes | Service > Settings > Domains |
+| Vercel | A (per-project IP from dashboard) | CNAME (per-project value from dashboard) | Yes | Project > Settings > Domains |
+| Render | A to `216.24.57.1` (or ANAME/ALIAS) | CNAME to `service.onrender.com` | Yes | Service > Settings > Custom Domains |
+| Netlify | ALIAS to `apex-loadbalancer.netlify.com` (A to `75.2.60.5` fallback) or Netlify DNS | CNAME to `site.netlify.app` | Yes | Site > Domain management |
+| Railway | CNAME flattening or ALIAS (no A record) | CNAME + TXT (from dashboard) | Yes | Service > Settings > Public Networking |
 | Fly.io | A (from `fly ips list`) | CNAME to `app.fly.dev` | Yes (`fly certs`) | CLI or dashboard |
-| Cloudflare Pages | Automatic (CF DNS) | CNAME to `project.pages.dev` | Yes | Pages > Custom domains |
+| Cloudflare Pages | Automatic (CF DNS) | CNAME to `project.pages.dev` | Yes | Workers & Pages > project > Custom domains |

--- a/guides/docker.md
+++ b/guides/docker.md
@@ -25,13 +25,13 @@ docker compose version
 
 ```dockerfile
 # -- Stage 1: Install dependencies --
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 
 # -- Stage 2: Production image --
-FROM node:20-alpine
+FROM node:24-alpine
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 WORKDIR /app
 
@@ -50,22 +50,24 @@ CMD ["node", "server.js"]
 **Why this works well:**
 - **Multi-stage build** -- separates dependency installation from the final image, keeping it small
 - **`npm ci`** -- installs exact versions from `package-lock.json` (reproducible builds)
-- **`--only=production`** -- excludes devDependencies from the image
+- **`--omit=dev`** -- excludes devDependencies from the image (the old `--only=production` flag is deprecated)
 - **Alpine base** -- ~50 MB instead of ~350 MB for the full Debian image
 - **Non-root user** -- security best practice (never run as root in production)
-- **HEALTHCHECK** -- lets orchestrators (ECS, Kubernetes, Compose) detect unhealthy containers
+- **HEALTHCHECK** -- lets Docker, Compose (`depends_on: service_healthy`), and Swarm detect unhealthy containers. Note: ECS and Kubernetes do NOT read the Dockerfile HEALTHCHECK -- ECS needs the check declared in the task definition, Kubernetes uses liveness/readiness probes in the Pod spec
+
+**Using pnpm instead of npm?** Enable it via Corepack and use `pnpm fetch` + `pnpm install --prod` in the deps stage (pnpm 11 requires Node 22.13+, so `node:24-alpine` works). See the [official pnpm Docker guide](https://pnpm.io/docker).
 
 ### Python Dockerfile
 
 ```dockerfile
 # -- Stage 1: Install dependencies --
-FROM python:3.12-slim AS builder
+FROM python:3.13-slim AS builder
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
 # -- Stage 2: Production image --
-FROM python:3.12-slim
+FROM python:3.13-slim
 RUN groupadd -r appgroup && useradd -r -g appgroup appuser
 WORKDIR /app
 
@@ -82,15 +84,16 @@ CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
 ```
 
 **Notes:**
-- `python:3.12-slim` is a good balance between size and compatibility (smaller than full, larger than alpine but avoids musl issues)
+- `python:3.13-slim` is a good balance between size and compatibility (smaller than full, larger than alpine but avoids musl issues); `python:3.14-slim` is the newest stable line
 - `--prefix=/install` isolates installed packages for clean copy into the final stage
 - `--no-cache-dir` prevents pip from caching downloaded packages in the image
+- If you use [uv](https://docs.astral.sh/uv/guides/integration/docker/) instead of pip: copy the static binary with `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/`, then `COPY pyproject.toml uv.lock ./` and `RUN uv sync --locked` -- same layer-caching benefits, much faster installs
 
 ### Go Dockerfile
 
 ```dockerfile
 # -- Stage 1: Build the binary --
-FROM golang:1.22-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
@@ -129,9 +132,9 @@ Stage 2 (final):   Copy only what you need       --> YOUR IMAGE
 
 | Approach | Image Size |
 |----------|-----------|
-| `node:20` (single stage) | ~350 MB |
-| `node:20-alpine` (single stage) | ~180 MB |
-| `node:20-alpine` (multi-stage) | ~80 MB |
+| `node:24` (single stage) | ~350 MB |
+| `node:24-alpine` (single stage) | ~180 MB |
+| `node:24-alpine` (multi-stage) | ~80 MB |
 
 To verify your image size:
 
@@ -180,6 +183,8 @@ build
 coverage
 .next
 ```
+
+For extra safety, prefer copying only the directories you need (`COPY src/ ./src`) over a blanket `COPY . .` -- belt and suspenders with `.dockerignore` against secrets or `.git` sneaking into image layers.
 
 ---
 
@@ -299,7 +304,7 @@ services:
     restart: unless-stopped
 
   mongo:
-    image: mongo:7
+    image: mongo:8
     ports:
       - "27017:27017"
     volumes:
@@ -335,7 +340,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     ports:
       - "5432:5432"
     environment:
@@ -390,7 +395,7 @@ services:
         condition: service_healthy
 
   mongo:
-    image: mongo:7
+    image: mongo:8
     ports:
       - "27017:27017"
     volumes:
@@ -402,7 +407,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     ports:
       - "6379:6379"
     volumes:
@@ -449,11 +454,32 @@ docker compose exec api sh
 docker compose exec db psql -U postgres -d myapp
 ```
 
+### Compose Watch (modern dev loop)
+
+Instead of relying only on bind-mount volumes, [Compose Watch](https://docs.docker.com/compose/how-tos/file-watch/) syncs file changes and rebuilds automatically:
+
+```yaml
+services:
+  api:
+    build: .
+    develop:
+      watch:
+        - action: sync          # Hot-reload: copy changed files into the container
+          path: ./src
+          target: /app/src
+        - action: rebuild       # Rebuild the image when dependencies change
+          path: package.json
+```
+
+```bash
+docker compose up --watch
+```
+
 ---
 
 ## Health Checks
 
-Health checks tell Docker (and orchestrators like ECS, Kubernetes) whether your container is working correctly.
+Health checks tell Docker whether your container is working correctly. Docker itself, Docker Compose (`depends_on: condition: service_healthy`), and Docker Swarm honor the Dockerfile `HEALTHCHECK`. ECS and Kubernetes do not: ECS only monitors health checks declared in the task definition, and Kubernetes ignores `HEALTHCHECK` entirely in favor of liveness/readiness/startup probes in the Pod spec.
 
 ### In Dockerfile
 
@@ -491,7 +517,8 @@ services:
 |-----------|-------------|-------------|
 | `interval` | Time between checks | 30s |
 | `timeout` | Max time for a check to complete | 5s |
-| `start_period` | Grace period on startup before checks count | 10-60s |
+| `start_period` | Grace period on startup before failures count | 10-60s |
+| `start_interval` | Check interval during the start period (faster "healthy" on boot) | 5s |
 | `retries` | Failures needed to mark unhealthy | 3 |
 
 Check container health status:
@@ -559,22 +586,32 @@ Docker caches each layer. Order your Dockerfile so frequently changing steps com
 ```dockerfile
 # GOOD: dependencies change less often than code
 COPY package*.json ./          # Layer 1: rarely changes
-RUN npm ci --only=production   # Layer 2: cached unless package.json changes
+RUN npm ci --omit=dev          # Layer 2: cached unless package.json changes
 COPY . .                       # Layer 3: changes with every code update
 
 # BAD: code change invalidates dependency cache
 COPY . .                       # Changes every time -> everything below re-runs
-RUN npm ci --only=production   # Re-installs every build
+RUN npm ci --omit=dev          # Re-installs every build
+```
+
+Go further with BuildKit cache mounts -- they persist the package manager's download cache across builds even when the dependency layer is invalidated:
+
+```dockerfile
+# npm
+RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
+
+# pip
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
 ```
 
 ### 4. Use Specific Image Tags
 
 ```dockerfile
-# GOOD: pinned version, reproducible
-FROM node:20.11-alpine
+# BEST: pinned to a digest, fully reproducible (Docker Scout can automate digest bumps)
+FROM node:24-alpine@sha256:<digest>
 
-# ACCEPTABLE: major version
-FROM node:20-alpine
+# GOOD: major version of a supported LTS line
+FROM node:24-alpine
 
 # BAD: unpredictable, may break
 FROM node:latest
@@ -657,6 +694,22 @@ Common causes:
 - Missing environment variables (e.g., `DATABASE_URL` not set)
 - Wrong CMD or ENTRYPOINT
 - Application error on startup
+
+### Problem: App runs inside the container but is unreachable from the host
+
+**Cause:** The server is bound to `localhost`/`127.0.0.1` inside the container. That interface is not reachable through the published port.
+
+**Fix:** Bind to `0.0.0.0`:
+
+```dockerfile
+# Python/uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+```js
+// Node.js
+app.listen(3000, '0.0.0.0');
+```
 
 ### Problem: "port is already allocated" error
 

--- a/guides/environment-variables.md
+++ b/guides/environment-variables.md
@@ -73,6 +73,8 @@ const dbUrl = process.env.DATABASE_URL;
 const port = process.env.PORT || 3000;
 ```
 
+**Native alternative:** Node.js can load `.env` files without any package: `node --env-file=.env app.js` (stable on Node 22/24). Use `--env-file-if-exists=.env` to skip the error when the file is missing. The `dotenv` package is still useful when the loading must happen inside code (e.g. library-level loading) rather than on the command line.
+
 **Note:** Vite, Next.js, and Create React App have built-in `.env` support. You do NOT need the `dotenv` package with these frameworks.
 
 ### Python (python-dotenv)
@@ -95,15 +97,14 @@ debug = os.getenv("DEBUG", "False").lower() == "true"
 **FastAPI example:**
 
 ```python
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
     database_url: str
     secret_key: str
     debug: bool = False
-
-    class Config:
-        env_file = ".env"
 
 settings = Settings()
 ```
@@ -143,14 +144,14 @@ PORT=3000
 CORS_ORIGIN=http://localhost:5173
 ```
 
-Commit `.env.example` to git so teammates know which variables are needed.
+Commit `.env.example` to git so teammates know which variables are needed. Treat it as the canonical variable list: if a secret exists in multiple places (local `.env`, platform dashboard, CI secrets), `.env.example` is the checked-in contract, and a rotated secret must be updated in every place or environments diverge silently.
 
 ### If You Accidentally Committed Secrets
 
 1. **Rotate the secret immediately.** Generate a new API key / password. The old one is compromised.
 2. Remove the file from tracking: `git rm --cached .env`
 3. Add to `.gitignore` and commit.
-4. Consider using `git filter-branch` or [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) to scrub history, but remember: **rotating the secret is the priority.**
+4. Consider using [git-filter-repo](https://github.com/newren/git-filter-repo) (GitHub's recommended tool, use version 2.47+ with `--sensitive-data-removal`) or [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) to scrub history, but remember: **rotating the secret is the priority.**
 
 ---
 
@@ -181,6 +182,8 @@ smtp host=...            # spaces not allowed
 | `REDIS_` | Redis configuration | `REDIS_URL`, `REDIS_PASSWORD` |
 | `APP_` | Application-specific | `APP_NAME`, `APP_ENV`, `APP_DEBUG` |
 
+**Tip:** Prefix your own backend variables with an app-specific prefix (e.g., `MYAPP_DATABASE_URL` via pydantic-settings' `env_prefix`). Platforms inject their own variables (`VERCEL_*`, `NEON_*`, `RENDER_*`), and a unique prefix guarantees no collisions.
+
 ---
 
 ## Build-Time vs Runtime Variables
@@ -198,9 +201,13 @@ This distinction is critical and is the source of many deployment bugs.
 
 **Docker containers** read runtime variables from the container environment, but `ARG` values in a Dockerfile are build-time only.
 
+**Gotcha:** If the build itself reads external services (e.g., Next.js SSG pages querying a database in `generateStaticParams`), the same variables production needs at runtime must ALSO exist at build time -- in the platform's env settings and in any CI job that runs the build.
+
 ---
 
 ## Framework-Specific Prefixes
+
+**Warning:** Prefixed variables (`VITE_`, `NEXT_PUBLIC_`, `REACT_APP_`) are baked into the public JavaScript bundle at build time. Anyone can read them in the browser. Never put secrets in them -- only URLs, feature flags, and other public config.
 
 ### Vite (React, Vue, Svelte)
 
@@ -224,6 +231,8 @@ const mode = import.meta.env.MODE; // 'development' or 'production'
 
 Vite loads `.env`, `.env.local`, `.env.development`, `.env.production` automatically based on the mode.
 
+**Tip:** In development, skip `VITE_API_URL` entirely by proxying API calls in `vite.config.ts` (`server: { proxy: { '/api': { target: 'http://localhost:8000', changeOrigin: true } } }`). The app calls relative `/api` paths locally with no CORS setup; only production builds need the baked-in API URL.
+
 ### Next.js
 
 Variables starting with `NEXT_PUBLIC_` are exposed to the browser. All others are server-only.
@@ -231,7 +240,7 @@ Variables starting with `NEXT_PUBLIC_` are exposed to the browser. All others ar
 ```env
 # Exposed to browser AND server
 NEXT_PUBLIC_API_URL=https://api.example.com
-NEXT_PUBLIC_ANALYTICS_ID=UA-XXXXXX
+NEXT_PUBLIC_ANALYTICS_ID=G-XXXXXXXXXX
 
 # Server-only (API routes, getServerSideProps, Server Components)
 DATABASE_URL=postgresql://...
@@ -263,7 +272,7 @@ Access in code:
 const apiUrl = process.env.REACT_APP_API_URL;
 ```
 
-**Note:** CRA is in maintenance mode. New projects should use Vite instead.
+**Note:** Create React App was officially deprecated by the React team on 2025-02-14 and has no active maintainers. This section applies to legacy CRA projects only. New projects should use Vite (or a framework like Next.js) instead.
 
 ---
 
@@ -297,7 +306,11 @@ jobs:
           echo "Deploying with version $APP_VERSION"
 ```
 
+Public build-time values (e.g., a frontend's `VITE_API_BASE_URL`) belong in Variables, not Secrets -- they are baked into the public bundle anyway, and Variables stay visible for debugging.
+
 **Environment-specific secrets:** Create environments (e.g., `staging`, `production`) under Settings > Environments to scope secrets per deployment target.
+
+**AWS deploys:** Prefer OIDC over storing long-lived `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets. Declare `permissions: id-token: write` and use `aws-actions/configure-aws-credentials@v4` with `role-to-assume` pointing at an IAM role that trusts GitHub's OIDC provider. Scope the role's trust policy `sub` claim per environment (e.g., `repo:OWNER/REPO:ref:refs/heads/main` for production, `repo:OWNER/REPO:pull_request` for previews) so PR workflows cannot assume the production role.
 
 ---
 
@@ -337,7 +350,7 @@ Variables are available at build time and runtime (for serverless functions). `N
 services:
   - type: web
     name: my-api
-    env: node
+    runtime: node
     envVars:
       - key: NODE_ENV
         value: production
@@ -361,13 +374,16 @@ The `sync: false` flag is important for secrets. It tells Render the value must 
 
 ```bash
 # Set a variable
-railway variables set DATABASE_URL="postgresql://..."
+railway variable set DATABASE_URL="postgresql://..."
 
 # Set multiple
-railway variables set NODE_ENV=production PORT=3000
+railway variable set NODE_ENV=production PORT=3000
 
 # List variables
-railway variables list
+railway variable list
+
+# Delete a variable
+railway variable delete OLD_API_KEY
 ```
 
 Railway supports **shared variables** across services in a project and **reference variables** that pull from other services (e.g., a database's connection string).
@@ -376,13 +392,13 @@ Railway supports **shared variables** across services in a project and **referen
 
 ### Netlify
 
-**Dashboard:** Site > Site configuration > Environment variables
+**Dashboard:** Project > Project configuration > Environment variables
 
 **netlify.toml:**
 
 ```toml
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22"
   NPM_FLAGS = "--prefix=/dev/null"
 
 # Environment-specific
@@ -504,6 +520,8 @@ python -c "import secrets; print(secrets.token_hex(64))"
 openssl rand -hex 64
 ```
 
+**Fail fast on weak secrets:** Have the app refuse to start in production if `JWT_SECRET` (or equivalent) is unset or shorter than 32 characters. A crash at boot is far better than silently signing tokens with an empty string.
+
 ---
 
 ## Secret Rotation Practices
@@ -550,6 +568,20 @@ For database passwords, use a rolling approach:
 4. **Check the environment scope.** On Vercel, variables can be scoped to Production only. Preview deploys will not see them.
 5. **Check .env file location.** The `.env` file must be in the project root (next to `package.json`), not in `src/`.
 
+### Variable Works in the App but Not in CLI Tools
+
+**Symptoms:** The framework sees `DATABASE_URL` but a CLI tool run from the same directory (ORM migrations, seed scripts) reports it missing.
+
+**Explanation:** Framework env loading is a framework feature. Next.js auto-loads `.env.local`, but tools like `drizzle-kit` do not, so `db:push` / `db:migrate` fail unless the config file loads it explicitly:
+
+```typescript
+// drizzle.config.ts
+import { config } from "dotenv";
+config({ path: ".env.local" });
+```
+
+For standalone scripts, pass the file on the command line: `tsx --env-file=.env.local seed.ts` or `node --env-file=.env app.js`.
+
 ### Build-Time vs Runtime Confusion
 
 **Symptoms:** Variable works locally but is `undefined` in production. Variable shows old value after changing on the platform.
@@ -584,6 +616,14 @@ For database passwords, use a rolling approach:
    echo -n 'complex!@#value' | base64
    # Store the base64 string, decode in your app
    ```
+
+### Connection String Query Parameters
+
+**Symptoms:** Database connects locally but fails on the deployment platform, often with an SSL or channel binding error.
+
+**Fixes:**
+1. **Neon pooled connections:** Neon's console appends `channel_binding=require` by default, but PgBouncer (the pooler) does not support channel binding. Use the pooler connection string with `?sslmode=require` and remove `channel_binding=require`.
+2. **Driver scheme mismatches:** SQLAlchemy with psycopg v3 needs `postgresql+psycopg://`, not the bare `postgresql://` most consoles hand out. Normalize the scheme in code or in the stored `DATABASE_URL`.
 
 ### Variables Not Available in CI/CD Forks
 

--- a/guides/fly-io.md
+++ b/guides/fly-io.md
@@ -2,14 +2,14 @@
 
 > Deploy containerized apps globally on Fly.io with multi-region support and built-in databases.
 
-Fly.io runs your applications in lightweight VMs (Firecracker micro-VMs) close to your users around the world. It uses Docker containers, supports multi-region deployments out of the box, and provides managed PostgreSQL and Redis. Fly.io is ideal for backend APIs, full-stack apps, and any workload that benefits from edge deployment.
+Fly.io runs your applications in lightweight VMs (Firecracker micro-VMs) close to your users around the world. It uses Docker containers, supports multi-region deployments out of the box, and provides Managed Postgres and Upstash Redis. Pricing is pure pay-as-you-go -- all new organizations require a credit card on file. Fly.io is ideal for backend APIs, full-stack apps, and any workload that benefits from edge deployment.
 
 ## Prerequisites
 
 - [ ] A [Fly.io account](https://fly.io/app/sign-up) (sign up with GitHub recommended)
 - [ ] [Git](https://git-scm.com/downloads) installed locally
-- [ ] [Node.js 18+](https://nodejs.org/) (for Node.js projects)
-- [ ] [Python 3.9+](https://www.python.org/downloads/) (for Python projects)
+- [ ] [Node.js 22+](https://nodejs.org/) (for Node.js projects)
+- [ ] [Python 3.12+](https://www.python.org/downloads/) (for Python projects)
 - [ ] [Docker](https://docs.docker.com/get-docker/) installed locally (for building images)
 - [ ] [Fly CLI (flyctl)](https://fly.io/docs/flyctl/install/): `curl -L https://fly.io/install.sh | sh`
 
@@ -68,7 +68,7 @@ Create `package.json`:
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.0"
+    "express": "^5.2.0"
   }
 }
 ```
@@ -78,7 +78,7 @@ Create `package.json`:
 Create `Dockerfile`:
 
 ```dockerfile
-FROM node:20-slim
+FROM node:24-slim
 
 WORKDIR /app
 
@@ -107,12 +107,16 @@ npm-debug.log
 # Initialize the Fly app (generates fly.toml)
 fly launch
 
-# Fly will ask:
-# - App name: my-express-app (or auto-generated)
-# - Region: choose the closest region (e.g., iad for Virginia)
-# - PostgreSQL: No (unless you need it)
-# - Redis: No (unless you need it)
-# - Deploy now: Yes
+# Fly prints a default configuration summary:
+# - Organization, app name (derived from the directory), fastest region
+# - App Machines: shared-cpu-1x, 1GB RAM (the default VM)
+# - Postgres: <none>, Redis: <none>
+# Then asks a single question:
+# "Do you want to tweak these settings before proceeding?"
+# Answer Yes to adjust settings in the Fly Launch web page, or No to deploy as-is.
+
+# Non-interactive alternative:
+fly launch --name my-express-app --region iad --no-db --no-redis --now --yes
 ```
 
 `fly launch` creates a `fly.toml` configuration file and deploys your app. You get a URL like `https://my-express-app.fly.dev`.
@@ -156,8 +160,8 @@ def health_check():
 Create `requirements.txt`:
 
 ```
-fastapi==0.109.0
-uvicorn[standard]==0.27.0
+fastapi==0.139.0
+uvicorn[standard]==0.50.1
 ```
 
 ### Step 2: Create a Dockerfile
@@ -165,7 +169,7 @@ uvicorn[standard]==0.27.0
 Create `Dockerfile`:
 
 ```dockerfile
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 
@@ -261,39 +265,40 @@ primary_region = "iad"
 
 ## PostgreSQL on Fly
 
-### Create a Postgres Cluster
+The current product is **Fly.io Managed Postgres (MPG)**, managed via the `fly mpg` commands. The old unmanaged Fly Postgres (`fly postgres create`) is legacy and unsupported -- Fly's docs state they cannot provide support or guidance for it. `fly launch --db mpg` provisions Managed Postgres during launch (`--db upg` or `--db legacy` keeps the old unmanaged path).
+
+Managed Postgres starts at the Basic plan: $38/mo (shared 2x CPU, 1GB RAM) plus $0.28 per provisioned GB of storage per 30-day month, available in 12 regions.
+
+### Create a Managed Postgres Cluster
 
 ```bash
-# Create a Postgres database attached to your app
-fly postgres create --name my-app-db
+# Create a Managed Postgres cluster (interactive: name, region, plan)
+fly mpg create
 
 # Attach it to your app (sets DATABASE_URL automatically)
-fly postgres attach my-app-db --app my-express-app
+fly mpg attach --app my-express-app
 ```
 
-This provisions a PostgreSQL cluster and automatically sets the `DATABASE_URL` secret in your app.
+This provisions a Managed Postgres cluster and automatically sets the `DATABASE_URL` secret in your app.
 
 ### Connect Locally
 
 ```bash
 # Proxy the database to localhost for local development
-fly proxy 5432 -a my-app-db
+fly mpg proxy
 
-# Connect with psql
+# Connect with psql using the connection string shown by the proxy
 psql "postgres://postgres:password@localhost:5432/my_app_db"
 ```
 
 ### Manage the Database
 
 ```bash
-# Connect to the Postgres console
-fly postgres connect -a my-app-db
-
-# List databases
-fly postgres db list -a my-app-db
+# Open a psql console on the cluster
+fly mpg connect
 
 # Check cluster status
-fly status -a my-app-db
+fly mpg status
 ```
 
 ---
@@ -310,10 +315,15 @@ fly redis create
 # - Name: my-app-redis
 # - Region: same as your app
 # - Eviction: enabled or disabled
-# - Plan: Free (25MB)
+# - Plan: pay-as-you-go ($0.20 per 100K requests, 10GB storage cap)
+#   or a fixed plan ($10/mo for 250MB up to $400/mo for 50GB)
 ```
 
-This sets the `REDIS_URL` (or `FLY_REDIS_CACHE_URL`) secret in your app.
+The command prints a private connection URL (e.g. `redis://password@fly-my-app-redis.upstash.io`). Set it as a secret yourself:
+
+```bash
+fly secrets set REDIS_URL="redis://password@fly-my-app-redis.upstash.io"
+```
 
 ### Use in Your App
 
@@ -357,14 +367,13 @@ fly machine clone --region nrt
 fly machine clone --region sin
 ```
 
-### Primary Region and Read Replicas
+### Primary Region and Databases
 
-For databases, use a primary region for writes and read replicas in other regions:
+Keep your database in (or close to) your app's primary region for write latency. Managed Postgres is available in 12 regions -- pick the region when running `fly mpg create`:
 
 ```bash
-# Create Postgres with read replicas
-fly postgres create --name my-app-db --region iad
-fly postgres create --name my-app-db-replica --region lhr
+fly mpg create
+# Choose the same region as your app's primary_region (e.g., iad)
 ```
 
 ### fly.toml Multi-Region Example
@@ -387,7 +396,7 @@ Fly.io uses `fly secrets` for sensitive environment variables and the `[env]` se
 |----------|-------------|---------|
 | `PORT` | Server port (set via `internal_port`) | `3000` |
 | `DATABASE_URL` | PostgreSQL connection string (auto-set) | `postgres://user:pass@host/db` |
-| `REDIS_URL` | Redis connection string (auto-set) | `redis://default:pass@host:6379` |
+| `REDIS_URL` | Redis connection string (set manually from `fly redis create` output) | `redis://default:pass@host:6379` |
 | `SECRET_KEY` | App secret key | `your-secret-key-here` |
 | `NODE_ENV` | Node environment | `production` |
 | `FLY_REGION` | Current region (auto-set by Fly) | `iad` |
@@ -476,26 +485,25 @@ Fly automatically provisions and renews SSL certificates via Let's Encrypt once 
 
 ---
 
-## Free Tier
+## Pricing
 
-Fly.io offers a generous free allowance (no credit card required for basic usage):
+Fly.io no longer offers free allowances or plans to new customers -- new organizations are pure pay-as-you-go, and all organizations require a credit card on file. (The old free allowances, like 3 shared-cpu-1x 256MB VMs, apply only to grandfathered legacy accounts.)
 
-| Feature | Free Allowance | Notes |
-|---------|---------------|-------|
-| **Shared CPU VMs** | Up to 3 shared-cpu-1x VMs (256MB each) | Always available |
-| **Outbound Bandwidth** | 160 GB/month | Across all apps |
-| **Anycast IPs** | Unlimited shared IPv4, 1 dedicated IPv4 | Shared IPv4 is free |
-| **Certificates** | 10 active SSL certificates | Auto-provisioned |
-| **Postgres** | 1 single-node cluster (256MB, 1GB disk) | Shared CPU |
-| **Upstash Redis** | 25MB, 200 connections | Via Fly partnership |
-| **Builders** | Unlimited remote builders | For Docker builds |
+| Feature | Price | Notes |
+|---------|-------|-------|
+| **Shared CPU VMs** | shared-cpu-1x 256MB from ~$2.02/mo | Billed per second while running |
+| **Outbound Bandwidth** | $0.02-$0.12/GB by region | Inbound is free |
+| **Anycast IPs** | Shared IPv4 free; dedicated IPv4 $2/mo | IPv6 is free |
+| **Certificates** | First 10 single-hostname SSL certs free, then $0.10/mo each | Auto-provisioned |
+| **Managed Postgres** | Basic plan from $38/mo + $0.28/GB storage per 30-day month | Shared 2x CPU, 1GB RAM |
+| **Upstash Redis** | Pay-as-you-go $0.20 per 100K requests; fixed plans $10-$400/mo | Via Fly partnership |
 
 ### Key things to know:
 
 - **Machines auto-stop by default.** When `auto_stop_machines = "stop"` is set, idle machines stop and restart on incoming requests (cold start of ~1-3 seconds).
-- **The free tier does not spin down permanently.** Machines stop when idle but restart automatically on traffic.
-- **Exceeding the free allowance** requires adding a credit card. You will not be charged without explicit action.
-- **Free Postgres is a single node** -- not suitable for production. Use Fly Postgres with multiple nodes for HA.
+- **Stopped machines cost almost nothing.** You pay only for rootfs storage while a machine is stopped, so auto-stop keeps low-traffic apps cheap.
+- **A credit card is required** for all new organizations before you can deploy.
+- **The Managed Postgres Basic plan is a starting point** -- scale the plan up for production HA workloads.
 
 ---
 
@@ -581,7 +589,7 @@ fly releases
 
 ### Problem: OOM (Out of Memory) kills
 
-**Cause:** The app exceeds the allocated memory for the VM. The default is 256MB for shared-cpu VMs.
+**Cause:** The app exceeds the allocated memory for the VM. `fly launch` defaults to shared-cpu-1x with 1GB RAM, but smaller configs (e.g., 256MB) hit this quickly.
 
 **Fix:**
 
@@ -617,7 +625,7 @@ fly ssh console -C "free -m"
 
 ```bash
 fly scale vm shared-cpu-2x   # 512MB RAM
-fly scale vm performance-1x  # 2GB RAM (paid)
+fly scale vm performance-1x  # 2GB RAM
 ```
 
 ### Problem: Volume mounting issues

--- a/guides/github-pages.md
+++ b/guides/github-pages.md
@@ -2,13 +2,13 @@
 
 > Deploy static sites, SPAs, and frontend apps for free with GitHub Pages.
 
-GitHub Pages serves static files directly from a GitHub repository. It supports custom domains, HTTPS, and automated deploys via GitHub Actions. Perfect for portfolios, documentation, and single-page applications.
+GitHub Pages serves static files directly from a GitHub repository. It supports custom domains, HTTPS, and automated deploys via GitHub Actions. Perfect for portfolios, documentation, and single-page applications. It is free, with soft limits: published sites up to 1 GB, 100 GB bandwidth per month, and 10 builds per hour for branch-based deploys (deploys via a custom GitHub Actions workflow are exempt from the build limit).
 
 ## Prerequisites
 
 - [ ] A [GitHub account](https://github.com/signup)
 - [ ] [Git](https://git-scm.com/downloads) installed locally
-- [ ] [Node.js 18+](https://nodejs.org/) (for React/Vue projects)
+- [ ] [Node.js 22+](https://nodejs.org/) (for React/Vue projects; Vite requires Node 20.19+ or 22.12+, and 24 is the current Active LTS)
 
 ## Deploy Static HTML
 
@@ -49,6 +49,14 @@ Your site will be live at `https://<username>.github.io/my-website/` within a fe
 npm create vite@latest my-react-app -- --template react
 cd my-react-app
 npm install
+```
+
+Or with pnpm:
+
+```bash
+pnpm create vite my-react-app --template react
+cd my-react-app
+pnpm install
 ```
 
 ### Step 2: Set the Base Path
@@ -92,6 +100,8 @@ GitHub Pages doesn't natively support client-side routing. Create a `public/404.
 </html>
 ```
 
+> **Tip:** A simpler alternative is to copy the built `index.html` to `404.html` in your deploy workflow (`cp dist/index.html dist/404.html` after the build step) -- Pages then serves your SPA for any deep link. If you use React Router's `BrowserRouter`, its `basename` must also match the Vite base (`<BrowserRouter basename="/my-react-app">`), or assets load but no routes match.
+
 ### Step 4: Deploy with GitHub Actions
 
 Create `.github/workflows/deploy.yml`:
@@ -116,17 +126,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
+
+      - uses: actions/configure-pages@v6
 
       - run: npm ci
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -138,8 +150,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
+
+> **Tip:** Using pnpm? Add a `pnpm/action-setup` step before `setup-node`, set `cache: pnpm`, and install with `pnpm install --frozen-lockfile` instead of `npm ci`.
 
 ### Step 5: Enable Pages with GitHub Actions Source
 
@@ -166,6 +180,8 @@ npm create vite@latest my-vue-app -- --template vue
 cd my-vue-app
 npm install
 ```
+
+Or with pnpm: `pnpm create vite my-vue-app --template vue`.
 
 ### Step 2: Set the Base Path
 
@@ -219,11 +235,11 @@ jobs:
   build-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/guides/hetzner.md
+++ b/guides/hetzner.md
@@ -6,7 +6,7 @@ Hetzner Cloud is a German IaaS provider with unbeatable EU pricing: the cheapest
 
 ## Prerequisites
 
-- [ ] A [Hetzner account](https://accounts.hetzner.com/signUp) with a payment method (no free tier -- billing starts when a server is created)
+- [ ] A [Hetzner account](https://console.hetzner.com/) with a payment method (no free tier -- billing starts when a server is created)
 - [ ] An SSH key pair (`ssh-keygen -t ed25519` if you don't have one)
 - [ ] [Git](https://git-scm.com/downloads) installed locally
 - [ ] (Optional) A domain name for HTTPS

--- a/guides/hetzner.md
+++ b/guides/hetzner.md
@@ -1,0 +1,484 @@
+# Hetzner Cloud
+
+> Deploy any Dockerized app on a Hetzner Cloud VPS with the hcloud CLI, cloud-init SSH hardening, Docker Compose, and Caddy HTTPS -- from about EUR 6/month.
+
+Hetzner Cloud is a German IaaS provider with unbeatable EU pricing: the cheapest server (CX23: 2 vCPU, 4 GB RAM, 40 GB SSD) costs EUR 5.49/month plus EUR 0.50/month for an IPv4 address -- EUR 5.99 total (~USD 7.09), with 20 TB of outgoing traffic included. There is no free tier, and prices went up for new orders on 2026-06-15, but it is still roughly a quarter of the price of a comparable DigitalOcean Droplet. Unlike Railway or Render, you manage the OS yourself -- this guide takes you from zero to a hardened Ubuntu 24.04 server running Docker Compose behind automatic Let's Encrypt HTTPS.
+
+## Prerequisites
+
+- [ ] A [Hetzner account](https://accounts.hetzner.com/signUp) with a payment method (no free tier -- billing starts when a server is created)
+- [ ] An SSH key pair (`ssh-keygen -t ed25519` if you don't have one)
+- [ ] [Git](https://git-scm.com/downloads) installed locally
+- [ ] (Optional) A domain name for HTTPS
+- [ ] (Optional) [Docker](https://docs.docker.com/get-docker/) locally, to test your image before deploying
+
+---
+
+## Plans and Pricing (verified 2026-07-06)
+
+Hetzner bills in EUR, per hour, capped at the monthly price. All prices below are per month, **excluding VAT and excluding the EUR 0.50 IPv4 surcharge**. The old CX22/CX32/CX42/CX52 and EU CPX11-51 plans were deprecated on 2026-01-01 -- if an older guide tells you to order a `cx22`, use `cx23` instead.
+
+### CX Gen3 -- shared Intel/AMD x86, EU only (cheapest line)
+
+| Plan | vCPU | RAM | SSD | EUR/mo |
+|------|------|-----|-----|--------|
+| `cx23` | 2 | 4 GB | 40 GB | 5.49 |
+| `cx33` | 4 | 8 GB | 80 GB | 8.49 |
+| `cx43` | 8 | 16 GB | 160 GB | 15.99 |
+| `cx53` | 16 | 32 GB | 320 GB | 29.49 |
+
+### CAX -- shared Ampere ARM64, EU only
+
+| Plan | vCPU | RAM | EUR/mo |
+|------|------|-----|--------|
+| `cax11` | 2 | 4 GB | 5.99 |
+| `cax21` | 4 | 8 GB | 10.49 |
+| `cax31` | 8 | 16 GB | 20.99 |
+| `cax41` | 16 | 32 GB | 40.99 |
+
+CAX11 includes a 40 GB SSD. ARM is great value if all your Docker images have `arm64` builds -- check before choosing.
+
+### CPX Gen2 -- shared AMD, EU and Singapore
+
+| Plan | vCPU | RAM | SSD | EU EUR/mo | Singapore EUR/mo |
+|------|------|-----|-----|-----------|------------------|
+| `cpx12` | 1 | 2 GB | 40 GB | n/a | 15.49 |
+| `cpx22` | 2 | 4 GB | 80 GB | 19.49 | 26.49 |
+| `cpx32` | 4 | 8 GB | 160 GB | 35.49 | 48.99 |
+| `cpx42` | 8 | 16 GB | 320 GB | 69.49 | n/a |
+| `cpx52` | 12 | 24 GB | 480 GB | 100.49 | n/a |
+| `cpx62` | 16 | 32 GB | 640 GB | 129.99 | n/a |
+
+### US locations -- CPX Gen1 only (no CX, no CAX)
+
+| Plan | vCPU | RAM | SSD | EUR/mo |
+|------|------|-----|-----|--------|
+| `cpx11` | 2 | 2 GB | 40 GB | 17.49 (USD 20.49) |
+| `cpx21` | | | | 31.99 |
+| `cpx31` | | | | 62.49 |
+| `cpx41` | | | | 120.49 |
+| `cpx51` | | | | 237.99 |
+
+US pricing is now far above EU pricing after the 2026-06-15 adjustment. If latency allows, deploy in the EU. Dedicated-vCPU CCX plans exist at all locations (CCX13 2 vCPU/8 GB from EUR 42.99/mo in the EU) but are overkill for hobby projects.
+
+### Locations
+
+| ID | City | Network zone | Available shared plans |
+|----|------|--------------|------------------------|
+| `fsn1` | Falkenstein, Germany | eu-central | CX, CAX, CPX |
+| `nbg1` | Nuremberg, Germany | eu-central | CX, CAX, CPX |
+| `hel1` | Helsinki, Finland | eu-central | CX, CAX, CPX |
+| `ash` | Ashburn, VA, USA | us-east | CPX Gen1 |
+| `hil` | Hillsboro, OR, USA | us-west | CPX Gen1 |
+| `sin` | Singapore | ap-southeast | CPX |
+
+Prices are identical across all three eu-central locations. This guide uses `fsn1` and `cx23` -- swap in `cpx11` + `ash` for US.
+
+---
+
+## Step 1: Create a Project and API Token
+
+1. Log in to the [Hetzner Console](https://console.hetzner.com/)
+2. Create a project (e.g., `my-app`) and open it
+3. Go to **Security** in the left menu > **API tokens** tab > **Generate API token**
+4. Name it (e.g., `cli`), select **Read & Write**, and generate
+
+> **Important:** The token is shown exactly once and cannot be viewed again. Copy it now. It is used as an `Authorization: Bearer $API_TOKEN` header by the API and CLI.
+
+## Step 2: Install the hcloud CLI
+
+The official CLI is [hcloud](https://github.com/hetznercloud/cli) (v1.66.0 as of 2026-06-24):
+
+```bash
+# macOS / Linux (Homebrew)
+brew install hcloud
+
+# Windows
+winget install HetznerCloud.CLI
+
+# Linux (binary)
+curl -sSLO https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-amd64.tar.gz
+sudo tar -C /usr/local/bin --no-same-owner -xzf hcloud-linux-amd64.tar.gz hcloud
+```
+
+Configure it with your API token and verify:
+
+```bash
+# Prompts for the API token from Step 1
+hcloud context create my-app
+
+# Verify -- lists plans with hourly/monthly prices and availability
+hcloud server-type list
+```
+
+> **Note:** Older tutorials verify with `hcloud datacenter list`. The `datacenters` commands were deprecated in v1.66.0 and the API endpoints are removed after 2026-10-01 -- use the `server-type` commands for availability instead.
+
+## Step 3: Upload Your SSH Key
+
+```bash
+hcloud ssh-key create --name my-key --public-key-from-file ~/.ssh/id_ed25519.pub
+```
+
+Always create servers with an SSH key. Without one, Hetzner emails you a root password, and password logins are exactly what the hardening in Step 5 disables.
+
+## Step 4: Create a Firewall
+
+Hetzner Cloud Firewalls are free and stateful. Create `rules.json`:
+
+```json
+[
+  {
+    "direction": "in",
+    "protocol": "tcp",
+    "port": "22",
+    "source_ips": ["0.0.0.0/0", "::/0"]
+  },
+  {
+    "direction": "in",
+    "protocol": "tcp",
+    "port": "80",
+    "source_ips": ["0.0.0.0/0", "::/0"]
+  },
+  {
+    "direction": "in",
+    "protocol": "tcp",
+    "port": "443",
+    "source_ips": ["0.0.0.0/0", "::/0"]
+  }
+]
+```
+
+```bash
+hcloud firewall create --name web-firewall --rules-file rules.json
+```
+
+> **Warning:** A firewall applied with **no rules blocks ALL inbound traffic** (outbound stays open). Always include the SSH rule before attaching a firewall, or you lock yourself out. Limits: 5 firewalls per server, 500 effective rules per firewall. If you know your home IP is static, replace `0.0.0.0/0` on port 22 with `<your-ip>/32` for a much smaller attack surface.
+
+## Step 5: Create the Server with Cloud-Init Hardening
+
+Cloud-init runs once at first boot -- perfect for creating a non-root user and locking down SSH before the server is ever exposed. Create `cloud-init.yaml` (replace the `ssh-ed25519 ...` line with your actual public key from `~/.ssh/id_ed25519.pub`):
+
+```yaml
+#cloud-config
+users:
+  - name: deploy
+    groups: users, sudo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAA...your-public-key... you@example.com
+
+package_update: true
+package_upgrade: true
+packages:
+  - fail2ban
+
+write_files:
+  - path: /etc/ssh/sshd_config.d/ssh-hardening.conf
+    content: |
+      PermitRootLogin no
+      PasswordAuthentication no
+      MaxAuthTries 2
+      AllowUsers deploy
+
+runcmd:
+  - printf "[sshd]\nenabled = true\n" > /etc/fail2ban/jail.local
+  - systemctl enable fail2ban
+  - reboot
+```
+
+This follows Hetzner's official [basic-cloud-config tutorial](https://community.hetzner.com/tutorials/basic-cloud-config): root login off, passwords off, fail2ban banning brute-forcers. The official version also moves SSH to port 2222 and enables ufw -- with a Hetzner firewall attached, ufw is redundant, and staying on port 22 keeps the firewall rule from Step 4 correct.
+
+Now create the server:
+
+```bash
+hcloud server create \
+  --name my-server \
+  --type cx23 \
+  --image ubuntu-24.04 \
+  --location fsn1 \
+  --ssh-key my-key \
+  --firewall web-firewall \
+  --user-data-from-file cloud-init.yaml
+```
+
+The command prints the server's IPv4 address when done. Wait a couple of minutes for cloud-init to finish (it upgrades packages and reboots), then connect **as `deploy`, not root**:
+
+```bash
+ssh deploy@<server-ip>
+
+# Confirm the hardening took effect (both should fail)
+ssh root@<server-ip>                        # Permission denied
+ssh -o PubkeyAuthentication=no deploy@<server-ip>  # Permission denied (no password prompt fallback accepted)
+```
+
+> **Tip:** IPv6 is free; the primary IPv4 costs EUR 0.50/month. If everything talking to your server supports IPv6, add `--without-ipv4` to skip the surcharge.
+
+## Step 6: Install Docker and Docker Compose
+
+On the server, use Docker's official apt repository (Ubuntu 24.04 is supported; current engine is the 29.x series, and Compose v2 ships as the `docker-compose-plugin`, invoked as `docker compose`):
+
+```bash
+# Add Docker's official GPG key and repository
+sudo apt update
+sudo apt install -y ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+
+# Install engine + Compose plugin
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Run docker without sudo
+sudo usermod -aG docker deploy
+newgrp docker
+
+# Verify
+docker compose version
+```
+
+Quick path if you prefer one command: `curl -fsSL https://get.docker.com -o get-docker.sh && sudo sh get-docker.sh`.
+
+## Step 7: Deploy Your App with Docker Compose
+
+Any app with a `Dockerfile` works. Example for a Node.js app listening on port 3000 -- `Dockerfile`:
+
+```dockerfile
+FROM node:22-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+EXPOSE 3000
+CMD ["node", "server.js"]
+```
+
+`compose.yaml`:
+
+```yaml
+services:
+  app:
+    build: .
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "127.0.0.1:3000:3000"
+```
+
+> **Important:** Bind to `127.0.0.1:3000:3000`, not `3000:3000`. Docker's published ports bypass most host firewalls -- binding to localhost keeps the app reachable only through the reverse proxy you add in Step 8.
+
+On the server:
+
+```bash
+git clone https://github.com/<username>/my-app.git
+cd my-app
+
+# Create the runtime env file (never commit this)
+cat > .env <<'EOF'
+NODE_ENV=production
+PORT=3000
+EOF
+chmod 600 .env
+
+docker compose up -d --build
+docker compose ps
+curl http://127.0.0.1:3000/
+```
+
+To redeploy after pushing changes:
+
+```bash
+cd ~/my-app && git pull && docker compose up -d --build
+```
+
+## Step 8: HTTPS with Caddy
+
+Caddy gets and renews Let's Encrypt certificates automatically -- zero certbot ceremony. Install on the server (it runs as the systemd service `caddy` automatically):
+
+```bash
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | \
+  sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | \
+  sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update && sudo apt install -y caddy
+```
+
+Point your domain's DNS at the server first (see Custom Domain below), then edit `/etc/caddy/Caddyfile`:
+
+```
+example.com {
+    reverse_proxy :3000
+}
+```
+
+```bash
+sudo systemctl reload caddy
+curl -I https://example.com
+```
+
+That's the whole HTTPS setup. Caddy fetches a publicly-trusted certificate as long as your DNS record points at the server and ports 80 and 443 are open (they are, from Step 4).
+
+### Alternative: nginx + certbot
+
+If you prefer nginx, use certbot via snap:
+
+```bash
+sudo apt install -y nginx
+sudo snap install --classic certbot
+sudo ln -s /snap/bin/certbot /usr/local/bin/certbot
+
+# Configure your nginx server block for example.com first, then:
+sudo certbot --nginx
+
+# Auto-renewal ships as a systemd timer -- verify it works
+sudo certbot renew --dry-run
+```
+
+`certbot --nginx` edits your nginx config and enables HTTPS in one step.
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `HCLOUD_TOKEN` | API token for the hcloud CLI in CI (locally, `hcloud context create` stores it for you) | `export HCLOUD_TOKEN=<token>` |
+| `NODE_ENV` | App environment | `production` |
+| `PORT` | Port your app listens on (must match `compose.yaml` and the Caddyfile) | `3000` |
+| `DATABASE_URL` | Connection string if you use an external DB (Neon, Supabase) | `postgresql://user:pass@host/db` |
+
+On a VPS there is no dashboard for app secrets -- they live in a `.env` file next to `compose.yaml`, loaded via `env_file`:
+
+```bash
+# On the server
+cat > ~/my-app/.env <<'EOF'
+NODE_ENV=production
+PORT=3000
+DATABASE_URL=postgresql://...
+EOF
+chmod 600 ~/my-app/.env
+
+# Apply changes
+cd ~/my-app && docker compose up -d
+```
+
+Add `.env` to `.gitignore`. For CI deploys (e.g., GitHub Actions running `hcloud` commands), store `HCLOUD_TOKEN` as a repo secret.
+
+---
+
+## Custom Domain
+
+1. Get your server's IPv4/IPv6 from `hcloud server list`
+2. At your DNS provider, add records for your domain:
+
+| Type | Name | Value |
+|------|------|-------|
+| A | @ | `<server-ipv4>` |
+| AAAA | @ | `<server-ipv6>` (optional) |
+| A | www | `<server-ipv4>` |
+
+3. Hetzner also offers free DNS hosting, now built into the Hetzner Console (moved there from the old dns.hetzner.com panel in late 2025) -- point your registrar's nameservers at Hetzner if you want everything in one place
+4. SSL is automatic: once the A record resolves to your server, Caddy obtains and renews the Let's Encrypt certificate on its own. With nginx, `certbot --nginx` handles issuance and the renewal timer
+
+Unlike PaaS platforms there is no CNAME target -- your domain points straight at the server IP, so the IPv4 stays yours until you delete it.
+
+---
+
+## Free Tier Info
+
+**Hetzner Cloud has no free tier.** Billing is hourly, capped at the monthly price, and starts the moment a server finishes creating -- powered-off servers are still billed. What the minimum setup actually costs (all excl. VAT):
+
+| Item | Price |
+|------|-------|
+| Cheapest x86 server (CX23, 2 vCPU / 4 GB / 40 GB, EU only) | EUR 5.49/mo (EUR 0.0088/hr) |
+| Cheapest ARM server (CAX11, 2 vCPU / 4 GB / 40 GB, EU only) | EUR 5.99/mo (EUR 0.0096/hr) |
+| Primary IPv4 | EUR 0.50/mo (USD 0.60) |
+| Primary IPv6 | Free |
+| Cloud Firewalls | Free |
+| Included outgoing traffic (EU, CX/CAX/CPX) | 20 TB/mo |
+| Traffic overage | EUR 1/TB (USD 1.20), billed in 100 MB blocks |
+| **Realistic minimum (CX23 + IPv4, EU)** | **EUR 5.99/mo (~USD 7.09)** |
+| Cheapest US option (CPX11, 2 vCPU / 2 GB / 40 GB) | EUR 17.49/mo (USD 20.49) + IPv4 |
+
+Only outgoing traffic counts against the quota; incoming and private-network traffic is free, and Hetzner emails warnings at 75% and 100%. US servers include 1-5 TB and Singapore 0.5-5 TB depending on plan.
+
+### vs DigitalOcean (prices fetched 2026-07-06)
+
+| | Hetzner CX23 (EUR 5.99 ~USD 7.09) | DO Basic $6/mo | DO Basic $24/mo |
+|--|-----------------------------------|----------------|-----------------|
+| vCPU | 2 | 1 | 2 |
+| RAM | 4 GB | 1 GiB | 4 GiB |
+| SSD | 40 GB | 25 GB | 80 GB |
+| Transfer | 20 TB | 1,000 GiB | 4 TB |
+
+Roughly 4x the RAM and 20x the transfer of DO's $6 Droplet, and about a quarter of the price of DO's comparable $24 Droplet. The catch: CX plans are EU-only, and DO's $4 Droplet (512 MiB) is still cheaper in absolute terms if you need almost nothing.
+
+### Billing gotchas
+
+- **Powered-off servers are billed.** "If you want to stop paying... you need to delete it." Snapshot first if you want the data back later.
+- **Every Primary IPv4 is billed, even unassigned ones.** Deleting a server can leave its IP behind -- delete unused IPs in **Console** > project > **Primary IPs**.
+- **The 2026-06-15 price increase only hits new orders and rescales.** Existing servers keep their old price as long as you never rescale.
+
+---
+
+## Troubleshooting
+
+### Problem: Outbound email never sends (SMTP connection timeouts)
+
+**Cause:** Hetzner blocks outbound ports 25 and 465 by default on ALL cloud servers to prevent spam abuse. New accounts must build history before an unblock is granted.
+
+**Fix:** Use a transactional relay on port 587 (Amazon SES, Postmark, Resend) instead of talking SMTP directly. If you genuinely need port 25, open a support request from the Console after your account has some history.
+
+### Problem: Locked out of SSH right after attaching a firewall
+
+**Cause:** A Hetzner firewall with zero rules (or without an SSH rule) blocks all inbound traffic, including your session's new connections.
+
+**Fix:** In **Console** > **Firewalls** > your firewall, add an inbound TCP port 22 rule from `0.0.0.0/0` and `::/0` -- takes effect immediately, no reboot. If you also broke sshd itself, use the server's **Console** (VNC) button in the Hetzner Console to get a local terminal. Prevention: always create firewalls from a `rules.json` that includes SSH, as in Step 4.
+
+### Problem: `server type cx22 not found` (or another old plan) when creating a server
+
+**Cause:** Hetzner replaced the old lineup in October 2025 with CX Gen3 (`cx23`-`cx53`) and CPX Gen2 (`cpx12`-`cpx62`). Since 2026-01-01, `cx22`, `cx32`, `cx42`, `cx52`, and EU `cpx11`-`cpx51` cannot be ordered in FSN, NBG, HEL, and SIN.
+
+**Fix:**
+
+```bash
+# See what is orderable right now, with prices
+hcloud server-type list
+```
+
+Use `cx23` instead of `cx22`. Existing servers on old plans keep working and can be moved to a new plan via the rescale option.
+
+### Problem: Still being charged after powering the server off
+
+**Cause:** Hetzner bills all servers that finished creation, including powered-off ones, plus every Primary IPv4 that exists -- "including Primary IPs that are not assigned to any cloud server."
+
+**Fix:** Snapshot the server in the Console if you need the data (server > **Snapshots**), then delete both the server and any orphaned IPs:
+
+```bash
+hcloud server delete my-server
+# Then check Console > Primary IPs and delete any unassigned IPv4s
+```
+
+### Problem: Cannot SSH into a server rebuilt from a snapshot
+
+**Cause:** Access after a rebuild depends on how the server was created. If no SSH key was selected at creation, Hetzner generates a new root password and emails it (set at first boot via cloud-init). If a key was selected, it is re-injected on first boot.
+
+**Fix:** Check the email for the new root password, or rely on the re-injected key. Keys that were already inside the snapshot's `authorized_keys` keep working regardless. Note that if your snapshot contains the hardening config from Step 5, root login and passwords stay disabled -- connect as `deploy` with your key.
+
+### Problem: OS image missing when creating a server (e.g., `fedora-42` not found)
+
+**Cause:** Hetzner keeps deprecated OS images for at least 3 months after the deprecation date, then removes them for new servers at any time (`fedora-42` was removed on 2026-06-30).
+
+**Fix:**
+
+```bash
+# List currently available system images
+hcloud image list --type system
+```
+
+Pin to a current LTS image like `ubuntu-24.04` in scripts and IaC. One related deprecation to watch: the EC2-compatible metadata routes (`/2009-04-04/meta-data` etc.) are deprecated as of 2026-06-30 and removed after 2026-08-01 -- tooling probing EC2-style metadata on Hetzner servers will break; only the documented `/hetzner/v1/*` routes remain.

--- a/guides/mongodb-atlas.md
+++ b/guides/mongodb-atlas.md
@@ -7,8 +7,8 @@ MongoDB Atlas is a fully managed cloud database service. The free tier (M0) give
 ## Prerequisites
 
 - [ ] A [MongoDB Atlas account](https://www.mongodb.com/cloud/atlas/register) (free)
-- [ ] [Node.js 18+](https://nodejs.org/) (for Node.js usage)
-- [ ] [Python 3.9+](https://www.python.org/downloads/) (for Python usage)
+- [ ] [Node.js 20.19+](https://nodejs.org/) (for Node.js usage; 22 or 24 LTS recommended)
+- [ ] [Python 3.12+](https://www.python.org/downloads/) (for Python usage)
 
 ---
 
@@ -16,7 +16,7 @@ MongoDB Atlas is a fully managed cloud database service. The free tier (M0) give
 
 1. Log in to [cloud.mongodb.com](https://cloud.mongodb.com/)
 2. Click **Build a Database** (or **Create** if you already have a project)
-3. Select **M0 FREE** tier
+3. Select the **Free** tier (M0)
 4. Choose a cloud provider and region (pick the one closest to your deployment platform):
    - **AWS** -- `us-east-1` works well with Render and Vercel
    - **GCP** or **Azure** -- also available
@@ -150,15 +150,20 @@ import mongoose from 'mongoose';
 const app = express();
 app.use(express.json());
 
-// Connect once at startup
-mongoose.connect(process.env.MONGODB_URI, { dbName: 'myapp' });
-
 app.get('/api/users', async (req, res) => {
   const users = await User.find();
   res.json(users);
 });
 
-app.listen(process.env.PORT || 3000);
+// Connect once at startup; only start listening after the DB is reachable.
+// Exiting on failure lets the platform restart the process instead of serving 500s.
+mongoose
+  .connect(process.env.MONGODB_URI, { dbName: 'myapp' })
+  .then(() => app.listen(process.env.PORT || 3000))
+  .catch((err) => {
+    console.error('MongoDB connection failed:', err);
+    process.exit(1);
+  });
 ```
 
 ---
@@ -168,8 +173,10 @@ app.listen(process.env.PORT || 3000);
 ### Install the Driver
 
 ```bash
-pip install pymongo[srv]
+pip install pymongo
 ```
+
+> Older guides say `pip install pymongo[srv]`. The `srv` extra was removed in PyMongo 4.8 -- plain `pymongo` now includes SRV support.
 
 ### Connect and Use
 
@@ -199,20 +206,22 @@ users.delete_one({"name": "Sagar Gupta"})
 client.close()
 ```
 
-### With Motor (Async Driver for FastAPI)
+### Async Usage (FastAPI)
+
+PyMongo ships a built-in async client (`AsyncMongoClient`) -- no extra package needed. The old async driver, Motor, was deprecated in May 2026 in favor of this API.
 
 ```bash
-pip install motor
+pip install pymongo
 ```
 
 ```python
 import os
-from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import AsyncMongoClient
 from fastapi import FastAPI
 
 app = FastAPI()
 
-client = AsyncIOMotorClient(os.environ["MONGODB_URI"])
+client = AsyncMongoClient(os.environ["MONGODB_URI"])
 db = client["myapp"]
 
 @app.get("/api/users")
@@ -312,6 +321,12 @@ async function connectDB() {
 }
 ```
 
+### Problem: Free cluster paused after a period of inactivity
+
+**Cause:** Atlas auto-pauses free (M0) clusters after 30 days with zero connections.
+
+**Fix:** Open the cluster in the Atlas UI and resume it. Any regular connection (a deployed app, a scheduled ping) prevents the pause.
+
 ### Problem: Free tier running out of storage
 
 **Cause:** M0 tier has a 512 MB limit.
@@ -321,4 +336,6 @@ async function connectDB() {
 1. Check usage in **Database** > **Metrics** > **Logical Size**
 2. Delete old or unnecessary data
 3. Add indexes to reduce storage overhead
-4. Upgrade to M2 ($9/month) or M5 ($25/month) for more storage
+4. Upgrade to a Flex cluster ($0.011/hour, usage-capped between $8/month and $30/month, 5 GB storage) or a Dedicated M10 cluster (from $0.08/hour, ~$57/month) for more storage
+
+> The old M2/M5 shared tiers no longer exist -- creation ended in February 2025 and all remaining M2/M5 clusters were migrated to Flex on January 22, 2026.

--- a/guides/monitoring.md
+++ b/guides/monitoring.md
@@ -1,0 +1,563 @@
+# Monitoring & Logging
+
+> Free-tier uptime monitoring, log management, error tracking, and cron alerting for small deployed apps.
+
+A deployed app you cannot observe is a deployed app you find out is broken from a user. This guide covers the current free tiers (verified 2026-07-06) of the most useful monitoring tools for hobby and indie projects: UptimeRobot, Better Stack, Sentry, Axiom, Grafana Cloud, and healthchecks.io, plus what Render, Railway, and Vercel give you natively. Every free tier here works without a credit card.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Picking Your Stack](#picking-your-stack)
+- [Uptime Monitoring: UptimeRobot](#uptime-monitoring-uptimerobot)
+- [Uptime and Logs: Better Stack](#uptime-and-logs-better-stack)
+- [Error Tracking: Sentry](#error-tracking-sentry)
+- [Log Management: Axiom](#log-management-axiom)
+- [Metrics and Dashboards: Grafana Cloud](#metrics-and-dashboards-grafana-cloud)
+- [Cron Monitoring: healthchecks.io](#cron-monitoring-healthchecksio)
+- [Platform-Native Logs: Render, Railway, Vercel](#platform-native-logs-render-railway-vercel)
+- [Alerting: Email, Slack, Discord Webhooks](#alerting-email-slack-discord-webhooks)
+- [Environment Variables](#environment-variables)
+- [Free Tier Info](#free-tier-info)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Prerequisites
+
+- [ ] A deployed app with a public URL ([Render](https://render.com/), [Railway](https://railway.com/), [Vercel](https://vercel.com/), or similar)
+- [ ] A health endpoint (e.g. `GET /health` returning HTTP 200) -- uptime monitors need something cheap to hit
+- [ ] [curl](https://curl.se/) installed locally (for testing ingest endpoints and webhooks)
+- [ ] Accounts on the tools you pick (each section links to signup; all free tiers below need no credit card)
+
+---
+
+## Picking Your Stack
+
+You do not need all six tools. A typical free setup for a small app:
+
+| Need | Tool | Why |
+|------|------|-----|
+| "Is my site up?" | UptimeRobot | 50 monitors free, dead simple |
+| "Did my nightly cron run?" | healthchecks.io | Purpose-built, 20 jobs free |
+| "What exception just hit production?" | Sentry | 5,000 errors/month free, stack traces + source maps |
+| "What did the app log yesterday?" | Axiom | 500 GB/month free ingest, 30-day retention |
+| Uptime + logs in one dashboard | Better Stack | 10 monitors at 30s checks + 3 GB logs free |
+| Metrics, dashboards, the full stack | Grafana Cloud | 10k metric series + 50 GB logs free |
+
+Platform-native logs (Render/Railway/Vercel) are your first stop for live debugging, but their free retention is short (1 hour to 7 days). Ship anything you care about to an external tool.
+
+---
+
+## Uptime Monitoring: UptimeRobot
+
+[UptimeRobot](https://uptimerobot.com/) pings your URL on a schedule and alerts you when it stops responding. The free plan gives 50 monitors at a 5-minute interval.
+
+### Step 1: Create an HTTP monitor
+
+1. Sign up at [uptimerobot.com](https://uptimerobot.com/) (free, no card).
+2. Dashboard > **New Monitor** > type **HTTP(s)**.
+3. URL: your health endpoint, e.g. `https://my-api.onrender.com/health`.
+4. Interval: 5 minutes (the free-plan minimum).
+5. Attach an alert contact (email is preconfigured; more integrations below).
+
+### Step 2: Add a heartbeat monitor for cron jobs
+
+Heartbeat monitoring inverts the check: UptimeRobot gives you a unique ping URL, your cron job hits it, and if pings stop arriving the monitor is marked down. Heartbeat monitors count within the 50 free monitors.
+
+```bash
+# End of your cron job -- only pings on success
+0 3 * * * /usr/local/bin/backup.sh && curl -fsS https://heartbeat.uptimerobot.com/m794yyyyyyyy-xxxxxxxxxxxxxxx
+```
+
+`wget -q -O /dev/null <url>` works too if curl is not installed.
+
+### Step 3: Wire up alert channels
+
+Free integrations include Email, Slack, Discord, Telegram, Webhooks, Microsoft Teams, Google Chat, PagerDuty, Zapier, Mattermost, Pushbullet, and Pushover. SMS and voice calls are available via purchasable credits. Configure under **Integrations & API** > add the channel, then attach it to each monitor.
+
+### Free tier and pricing
+
+| Plan | Price | Monitors | Interval | Extras |
+|------|-------|----------|----------|--------|
+| Free | $0 | 50 | 5 min | 1 basic status page, 3 months data retention |
+| Solo | $84/year | -- | 60s | -- |
+| Team | $348/year | 100 | 60s | -- |
+| Enterprise | $648+/year | more | 30s | -- |
+
+Annual billing saves about 20% versus monthly.
+
+---
+
+## Uptime and Logs: Better Stack
+
+[Better Stack](https://betterstack.com/) combines uptime monitoring, log management, and incident alerting. The free tier is generous on check frequency: 30-second intervals, versus UptimeRobot's 5 minutes.
+
+### Step 1: Create an uptime monitor
+
+1. Sign up at [betterstack.com](https://betterstack.com/) (free).
+2. **Uptime** > **Monitors** > **Create monitor** > enter your health URL.
+3. Set check frequency (down to 30 seconds on the free tier).
+
+### Step 2: Ship logs to a source
+
+Create a source under **Telemetry** > **Sources** > **Connect source**. Grab the token from **Sources** > your source > **Configure** > **Basic information**, then POST JSON to your source's ingesting host:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $SOURCE_TOKEN" \
+  -d '{"dt":"2026-07-06 12:00:00 UTC","message":"Hello from Better Stack!"}' \
+  "https://$INGESTING_HOST"
+```
+
+In production you would use their SDK or a log drain rather than raw curl, but this one-liner proves the pipeline works. Free tier: 3 GB/month of logs, retained 3 days.
+
+### Step 3: Add a heartbeat monitor for cron jobs
+
+**Uptime** > **Heartbeats** > **Create heartbeat**. Your script pings the heartbeat URL; an incident triggers if no heartbeat arrives within the configured frequency plus grace period.
+
+```bash
+# Success ping
+curl "https://uptime.betterstack.com/api/v1/heartbeat/<HEARTBEAT_TOKEN>"
+
+# Report failure explicitly
+curl "https://uptime.betterstack.com/api/v1/heartbeat/<HEARTBEAT_TOKEN>/fail"
+
+# Or report the shell exit code of the previous command
+/usr/local/bin/backup.sh
+curl "https://uptime.betterstack.com/api/v1/heartbeat/<HEARTBEAT_TOKEN>/$?"
+```
+
+A new heartbeat stays **Pending** until the first ping arrives, so trigger your job once manually after creating it.
+
+### Free tier and pricing
+
+| Resource | Free tier |
+|----------|-----------|
+| Uptime monitors | 10, up to 30-second check frequency |
+| Logs | 3 GB/month, 3-day retention |
+| Traces | 3 GB, 3-day retention |
+| Metrics | 30 GB |
+| Exceptions | 100,000/month |
+| Session replays | 5,000 |
+
+Paid Responder plan: $34/month ($29/month billed yearly).
+
+---
+
+## Error Tracking: Sentry
+
+[Sentry](https://sentry.io/) captures unhandled exceptions with stack traces, breadcrumbs, and release tracking. The free Developer plan covers 5,000 errors/month, which is plenty for a small app.
+
+### Step 1: Install the SDK (Node.js)
+
+Requires Node >= 18.0.0 (>= 18.19.0 recommended). Current version: @sentry/node 10.63.0.
+
+```bash
+npm install @sentry/node
+```
+
+### Step 2: Initialize before anything else
+
+Create `instrument.js` and make sure it loads before any other module:
+
+```javascript
+// instrument.js
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "https://<key>@o<orgId>.ingest.sentry.io/<projectId>",
+  tracesSampleRate: 1.0,
+});
+```
+
+```bash
+# Load it first via --require so no app code runs uninstrumented
+node --require ./instrument.js app.js
+```
+
+The DSN is on your project's **Settings** > **Client Keys (DSN)** page. Test it by throwing an error and checking the Issues feed.
+
+### Step 3: Upload source maps (optional but worth it)
+
+Minified stack traces are useless. The wizard configures source map upload for your bundler:
+
+```bash
+npx @sentry/wizard@latest -i sourcemaps
+```
+
+### Step 4: Monitor a cron job with Sentry Crons
+
+The free plan includes 1 cron monitor. Create it under **Crons**, then check in over HTTP:
+
+```bash
+SENTRY_CRONS="https://o<orgId>.ingest.sentry.io/api/<projectId>/cron/<monitor_slug>/<public-key>/"
+
+curl "${SENTRY_CRONS}?status=in_progress"
+if /usr/local/bin/backup.sh; then
+  curl "${SENTRY_CRONS}?status=ok"
+else
+  curl "${SENTRY_CRONS}?status=error"
+fi
+```
+
+Optional query params: `environment=` and `check_in_id=`.
+
+### Step 5: Stay under quota
+
+Events and attachments that exceed your quota are not accepted -- they are dropped, not billed. Volume-reduction options in order of ease: spike protection, per-project rate limiting, inbound filters, SDK sampling (`tracesSampleRate` below 1.0), and `beforeSend` callback filtering:
+
+```javascript
+Sentry.init({
+  dsn: "...",
+  tracesSampleRate: 0.1,
+  beforeSend(event) {
+    // Drop noisy, known-harmless errors before they count against quota
+    if (event.exception?.values?.[0]?.type === "AbortError") return null;
+    return event;
+  },
+});
+```
+
+### Free tier and pricing
+
+| Resource | Developer (free) |
+|----------|------------------|
+| Errors | 5,000/month |
+| Spans | 5M |
+| Session replays | 50 |
+| Cron monitors | 1 |
+| Uptime monitors | 1 |
+| Users | 1 |
+| Retention | 30 days |
+
+Paid: Team $26/month, Business $80/month (billed annually).
+
+---
+
+## Log Management: Axiom
+
+[Axiom](https://axiom.co/) is the volume king of free log tiers: 500 GB/month ingest with 30-day retention on the Personal plan. If your platform's log retention is too short (looking at you, Vercel Hobby), ship logs here.
+
+### Step 1: Create a dataset and API token
+
+1. Sign up at [axiom.co](https://axiom.co/) (Personal plan, free).
+2. Create a dataset (Personal plan allows 3).
+3. **Settings** > **API tokens** > create a token with ingest permission for that dataset.
+
+### Step 2: Ingest events
+
+```bash
+curl -X POST "https://api.axiom.co/v1/datasets/my-app-logs/ingest" \
+  -H "Authorization: Bearer $AXIOM_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '[{"level":"error","message":"payment failed","user_id":"u_123"}]'
+```
+
+For newline-delimited JSON, an alternate documented path form is `/v1/ingest/DATASET_NAME` with `Content-Type: application/x-ndjson`.
+
+### Step 3: Know the limits
+
+- Max 10,000 events per batch
+- Max field size 1 MB, max field name 200 bytes
+- Personal plan datasets are capped at 256 fields each -- events exceeding the field limit are rejected with an error
+- The 500 GB/month ingest cap is a hard ceiling; heavy senders may be temporarily rate-restricted
+
+Flatten your log structure and avoid dynamic field names (e.g. do not use user IDs as JSON keys) or you will burn through the 256-field cap fast.
+
+### Free tier and pricing
+
+| Resource | Personal (free) |
+|----------|-----------------|
+| Ingest | 500 GB/month (hard cap) |
+| Retention | 30 days maximum |
+| Datasets | 3 |
+| Users | 1 |
+| Monitors | 3 |
+
+Paid Axiom Cloud: usage-based with a $25/month platform fee ($0.06-$0.12/GB loading, $0.030/GB compressed storage), plus always-free allowances of 1,000 GB loading and 100 GB storage.
+
+---
+
+## Metrics and Dashboards: Grafana Cloud
+
+[Grafana Cloud](https://grafana.com/) bundles Grafana dashboards, Prometheus-compatible metrics (Mimir), logs (Loki), traces (Tempo), and synthetic monitoring in one free stack. Heaviest to set up, most capable once running.
+
+### Step 1: Create a free stack
+
+Sign up at [grafana.com](https://grafana.com/) -- the Free tier needs no credit card. You get a hosted Grafana instance plus endpoints for metrics, logs, and traces.
+
+### Step 2: Push a log line to Loki
+
+Find your Loki endpoint, User ID, and API token under your stack's Loki data source settings. Loki timestamps are unix epoch in nanoseconds:
+
+```bash
+curl -u "$LOKI_USER_ID:$GRAFANA_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -X POST "https://<loki-host>/loki/api/v1/push" \
+  -d '{
+    "streams": [{
+      "stream": { "app": "my-api", "level": "error" },
+      "values": [[ "'"$(date +%s%N)"'", "payment failed for user u_123" ]]
+    }]
+  }'
+```
+
+Query it back in Grafana > Explore with `{app="my-api"}`.
+
+### Step 3: Use synthetic monitoring as your uptime checker
+
+The free tier includes 100k synthetic API test executions and 10k browser test executions per month -- enough to health-check a handful of endpoints every few minutes from multiple regions, replacing a separate uptime tool if you are already invested in Grafana.
+
+### Free tier and pricing
+
+| Resource | Free tier |
+|----------|-----------|
+| Metrics | 10k active series, 14-day retention |
+| Logs | 50 GB/month, 14-day retention |
+| Traces | 50 GB/month, 14-day retention |
+| Profiles | 50 GB/month, 14-day retention |
+| Grafana users | 3 active |
+| IRM/OnCall users | 3 |
+| Synthetic tests | 100k API + 10k browser executions/month |
+| k6 load testing | 500 virtual user hours/month |
+
+Paid Pro: $19/month platform fee plus usage (e.g. logs $0.05/GB process + $0.40/GB write + $0.10/GB retain; metrics $6.50 per 1k series past the allowance).
+
+---
+
+## Cron Monitoring: healthchecks.io
+
+[healthchecks.io](https://healthchecks.io/) does one thing: dead-man's-switch monitoring for scheduled jobs. If your backup script stops pinging, you get an alert. Free Hobbyist plan monitors 20 jobs.
+
+### Step 1: Create a check
+
+1. Sign up at [healthchecks.io](https://healthchecks.io/) (free).
+2. **Add Check**, set the schedule (simple period or a cron expression matching your job).
+3. Set the **grace time** -- the extra wait after the expected time before alerting. Size it to absorb your job's normal runtime variance.
+
+### Step 2: Ping from your job
+
+Two URL formats: `https://hc-ping.com/<uuid>` or slug-based `https://hc-ping.com/<project-ping-key>/<name-slug>`. Treat UUIDs and ping keys as secrets -- anyone holding them can fake your pings.
+
+```bash
+# Minimal: success ping at the end of the job
+0 3 * * * /usr/local/bin/backup.sh && curl -fsS -m 10 --retry 3 https://hc-ping.com/<uuid>
+```
+
+```bash
+# Full pattern: signal start, then report the exit code
+#!/bin/sh
+curl -fsS -m 10 --retry 3 "https://hc-ping.com/<uuid>/start"
+/usr/local/bin/backup.sh
+curl -fsS -m 10 --retry 3 "https://hc-ping.com/<uuid>/$?"
+```
+
+`/start` enables runtime measurement, `/fail` signals explicit failure, `/<exitcode>` reports the exit status (0 = success, anything else = failure).
+
+### Step 3: Understand the states
+
+Checks move through **New** > **Up** > **Late** > **Down** (plus **Paused**). A check goes Late when overdue and Down -- which is when alerts fire -- only after the grace time is exceeded. Alerting supports email, webhooks, SMS, Slack, PagerDuty, and more.
+
+### Free tier and pricing
+
+| Plan | Price | Jobs | Log entries/job | Extras |
+|------|-------|------|-----------------|--------|
+| Hobbyist | $0/month | 20 | 100 | -- |
+| Supporter | $5/month | 20 | 100 | identical limits to free |
+| Business | $20/month | 100 | 1,000 | 50 SMS/WhatsApp + 20 call credits |
+| Business Plus | $80/month | 1,000 | -- | -- |
+
+Qualifying open-source projects can request free plan upgrades.
+
+---
+
+## Platform-Native Logs: Render, Railway, Vercel
+
+Your platform's built-in logs are the first thing you check, and the first thing that silently expires. Know the retention windows.
+
+### Render
+
+| Workspace plan | Log retention |
+|----------------|---------------|
+| Hobby | 7 days |
+| Pro | 14 days |
+| Scale / Enterprise | 30 days |
+
+Logs older than the current retention period are gone even if you upgrade later. The dashboard Logs page supports text search and filters (level, instance, method, status_code, host, path). HTTP request logs require a Pro workspace or higher.
+
+CLI access:
+
+```bash
+brew install render-oss/render/render
+# or download a binary from https://github.com/render-oss/cli/releases/
+
+render login    # opens browser, saves a token
+render services # pick a service, then view and filter live logs interactively
+```
+
+Free-tier gotcha for uptime monitors: free web services spin down after 15 minutes without inbound traffic (HTTP or WebSocket) and take about one minute to spin up. Each workspace gets 750 free instance hours/month; spun-down services do not consume hours. While spun down, Render still answers `robots.txt` without waking the service, which can confuse some monitoring systems. See [Troubleshooting](#troubleshooting).
+
+### Railway
+
+| Plan | Log retention |
+|------|---------------|
+| Hobby / Trial | 7 days |
+| Pro | 30 days |
+| Enterprise | up to 90 days |
+
+```bash
+railway logs   # view deployment logs
+```
+
+Hard limit on all plans: 500 log lines per second per replica. Excess lines are dropped with a warning showing the drop count.
+
+### Vercel
+
+| Plan | Runtime log retention |
+|------|-----------------------|
+| Hobby | 1 hour |
+| Pro | 1 day |
+| Pro + Observability Plus | 30 days |
+| Enterprise | 3 days |
+| Enterprise + Observability Plus | 30 days |
+
+Per-request limits: 256 log lines, 256 KB per line, 1 MB total per request. View logs via the project sidebar **Logs** tab with filters (level, route, host, status code, environment, branch).
+
+**Drains** (forwarding logs/traces to external services like Axiom or Better Stack) are Pro and Enterprise only -- Hobby users must upgrade. Drain volume is billed at $0.50/GB on Pro. Supported data types: logs, traces, speed insights, web analytics, and audit logs (audit logs Enterprise-only). On Hobby, the workaround is shipping logs from inside your function code at write time (see Troubleshooting).
+
+---
+
+## Alerting: Email, Slack, Discord Webhooks
+
+Every tool above supports email out of the box. For team channels, wire up a webhook once and reuse it everywhere.
+
+### Slack incoming webhook
+
+1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps).
+2. Enable **Incoming Webhooks**, then **Add New Webhook to Workspace** and pick a channel.
+3. You get one URL per workspace+channel pair, format `hooks.slack.com/services/<team-id>/<channel-id>/<token>`.
+
+```bash
+curl -X POST -H "Content-type: application/json" \
+  -d '{"text":"Alert: my-api /health returned 500."}' \
+  "$SLACK_WEBHOOK_URL"
+```
+
+Success returns HTTP 200 with body `ok`. Webhook URLs are secrets, and they cannot override channel, username, or icon -- one URL, one destination.
+
+### Discord webhook
+
+Channel settings > **Integrations** > **Webhooks** > **New Webhook** > copy URL.
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"content":"Alert: my-api /health returned 500."}' \
+  "https://discord.com/api/webhooks/<webhook.id>/<webhook.token>"
+```
+
+- `content` max 2,000 characters, up to 10 embeds per message
+- Append `?wait=true` to get the created message back in the response
+- **Slack-compat trick:** Discord exposes `/webhooks/<id>/<token>/slack` and `/webhooks/<id>/<token>/github` endpoints. If a monitoring tool only offers a "Slack" integration, paste your Discord webhook URL with `/slack` appended and it just works.
+
+### Which channel from which tool
+
+| Tool | Email | Slack | Discord | Webhook | SMS/Voice |
+|------|-------|-------|---------|---------|-----------|
+| UptimeRobot | yes | yes | yes | yes | paid credits |
+| Better Stack | yes | yes | via generic webhook | yes | on paid plans |
+| Sentry | yes | yes | via webhook | yes | no |
+| Grafana Cloud | yes | yes | yes | yes | via OnCall |
+| healthchecks.io | yes | yes | via Slack-compat URL | yes | Business plan credits |
+
+---
+
+## Environment Variables
+
+Secrets used in this guide. Set them on your platform per the [Environment Variables guide](./environment-variables.md) -- never commit them.
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `SENTRY_DSN` | Sentry project ingest URL | `https://<key>@o<orgId>.ingest.sentry.io/<projectId>` |
+| `SENTRY_CRONS` | Sentry cron check-in base URL | `https://o<orgId>.ingest.sentry.io/api/<projectId>/cron/<slug>/<public-key>/` |
+| `AXIOM_TOKEN` | Axiom API token with ingest permission | `xaat-xxxxxxxx` |
+| `SOURCE_TOKEN` | Better Stack log source token | from Sources > Configure > Basic information |
+| `INGESTING_HOST` | Better Stack ingesting host for your source | shown next to the source token |
+| `HEARTBEAT_TOKEN` | Better Stack heartbeat token | from the heartbeat's URL |
+| `LOKI_USER_ID` | Grafana Cloud Loki user ID | from the stack's Loki data source settings |
+| `GRAFANA_API_TOKEN` | Grafana Cloud API token | paired with `LOKI_USER_ID` for basic auth |
+| `SLACK_WEBHOOK_URL` | Slack incoming webhook | `https://hooks.slack.com/services/T.../B.../XXX...` |
+| `DISCORD_WEBHOOK_URL` | Discord channel webhook | `https://discord.com/api/webhooks/<id>/<token>` |
+
+healthchecks.io ping UUIDs and UptimeRobot heartbeat URLs are secrets too, even though they usually live inside crontabs rather than env vars.
+
+---
+
+## Free Tier Info
+
+All limits verified 2026-07-06 against each vendor's pricing page.
+
+| Tool | Free tier headline | Retention | Cheapest paid |
+|------|--------------------|-----------|---------------|
+| UptimeRobot | 50 monitors, 5-min interval, 1 basic status page | 3 months data | Solo $84/year (60s interval) |
+| Better Stack | 10 uptime monitors (30s checks), 3 GB logs/month, 100k exceptions/month | logs/traces 3 days | Responder $34/month ($29/month yearly) |
+| Sentry | 5,000 errors/month, 5M spans, 1 cron + 1 uptime monitor, 1 user | 30 days | Team $26/month (annual) |
+| Axiom | 500 GB/month ingest (hard cap), 3 datasets, 3 monitors, 1 user | 30 days max | Cloud $25/month platform fee + usage |
+| Grafana Cloud | 10k metric series, 50 GB logs + 50 GB traces + 50 GB profiles/month, 3 users | 14 days | Pro $19/month + usage |
+| healthchecks.io | 20 jobs, 100 log entries/job | -- | Business $20/month (100 jobs) |
+| Render logs | included with service | Hobby 7 days | Pro workspace: 14 days + HTTP request logs |
+| Railway logs | included with service | Hobby 7 days | Pro: 30 days |
+| Vercel logs | included with project | Hobby 1 hour | Pro: 1 day; +Observability Plus: 30 days |
+
+---
+
+## Troubleshooting
+
+### Problem: Uptime monitor reports a Render free app as down (or extremely slow) every few hours
+
+**Cause:** Render free services spin down after 15 minutes without inbound traffic and take about one minute to spin up. The first check after a sleep either times out or records a huge response time. Render also answers `robots.txt` without waking the service while spun down, which confuses some monitors.
+
+**Fix:** Point an external uptime check at the service at a 5-minute interval (UptimeRobot free works) -- the checks themselves count as traffic and keep it awake. Or accept the wake latency and raise the monitor's timeout. For anything real, upgrade off the Free instance type; Render explicitly says not to use Free instances for production.
+
+### Problem: Yesterday's error is gone from Vercel logs
+
+**Cause:** Runtime logs on the Hobby plan are only queryable for 1 hour. Debugging anything older than that from the dashboard is impossible, and Drains (log forwarding) require Pro.
+
+**Fix:** Ship logs out at write time from inside the function -- POST errors to Axiom or Better Stack in the same request that logs them:
+
+```javascript
+await fetch("https://api.axiom.co/v1/datasets/my-app-logs/ingest", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.AXIOM_TOKEN}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify([{ level: "error", message: err.message, stack: err.stack }]),
+});
+```
+
+### Problem: Railway logs are missing lines under load
+
+**Cause:** Railway drops log lines beyond 500 lines per second per replica on all plans. Excess lines are dropped with a warning showing the drop count.
+
+**Fix:** Per Railway's docs: reduce verbosity in production, emit minified JSON instead of pretty-printed output, sample frequent events, and consolidate related entries into single lines.
+
+### Problem: Sentry events stop appearing mid-month
+
+**Cause:** You hit the Developer plan's 5,000 errors/month quota. Events exceeding quota are not accepted -- they vanish, no error on your side.
+
+**Fix:** Lower volume before raising spend: SDK sampling (`tracesSampleRate`), `beforeSend` filtering of known-noisy errors, inbound filters, or per-project rate limits. Check **Stats & Usage** to see what is eating the quota.
+
+### Problem: Axiom rejects ingest requests with a field-limit error
+
+**Cause:** An event that would exceed the dataset's allowed field count (256 fields on the Personal plan) is rejected with an error rather than stored. Dynamic JSON keys (user IDs, request IDs as field names) blow through the cap fast. Batches over 10,000 events or fields over 1 MB also fail.
+
+**Fix:** Flatten and limit log fields; move dynamic values into field *values*, not field *names* (`{"user_id":"u_123"}`, never `{"u_123":{...}}`). Split oversized batches.
+
+### Problem: healthchecks.io alerts on cron jobs that ran fine, just slightly late
+
+**Cause:** A check goes Late when overdue and Down (which alerts) only after grace time is exceeded. For cron-scheduled checks, grace starts counting at the scheduled execution time -- so a job with variable runtime and a tight grace window fires false alarms.
+
+**Fix:** Raise the check's grace time to absorb expected runtime variance (e.g. a backup that takes 5-20 minutes needs at least 25-30 minutes of grace). Use the `/start` ping so healthchecks.io can also measure actual runtime.

--- a/guides/neon.md
+++ b/guides/neon.md
@@ -2,13 +2,13 @@
 
 > Set up a free serverless PostgreSQL database with Neon, get a connection string, and use it in Python and Node.js.
 
-Neon is a serverless PostgreSQL provider that separates storage and compute, giving you features like branching, autoscaling, and a generous free tier. The free plan includes 0.5 GB of storage and 191 compute hours per month.
+Neon (acquired by Databricks in 2025, still runs as its own product) is a serverless PostgreSQL provider that separates storage and compute, giving you features like branching, autoscaling, and a generous free tier. The free plan includes 0.5 GB of storage and 100 CU-hours of compute per project per month, across up to 100 projects.
 
 ## Prerequisites
 
-- [ ] A [Neon account](https://neon.tech/) (sign up with GitHub for easiest setup)
-- [ ] [Python 3.9+](https://www.python.org/downloads/) (for Python usage)
-- [ ] [Node.js 18+](https://nodejs.org/) (for Node.js usage)
+- [ ] A [Neon account](https://neon.com/) (sign up with GitHub for easiest setup)
+- [ ] [Python 3.12+](https://www.python.org/downloads/) (for Python usage)
+- [ ] [Node.js 22+](https://nodejs.org/) (for Node.js usage)
 
 ---
 
@@ -18,11 +18,11 @@ Neon is a serverless PostgreSQL provider that separates storage and compute, giv
 2. Click **New Project**
 3. Configure:
    - **Project name:** `my-project`
-   - **Postgres version:** 16 (latest)
+   - **Postgres version:** 18 (default for new projects; 14-18 supported)
    - **Region:** Select the one closest to your deployment platform (e.g., `US East` for Render/Vercel)
 4. Click **Create Project**
 
-The project is created instantly with a default database called `neondb` and a default branch called `main`.
+The project is created instantly with a default database called `neondb` and a root branch called `production` (projects created via the API or CLI get a root branch named `main` instead).
 
 ---
 
@@ -33,17 +33,17 @@ After creating the project, Neon immediately shows your connection details. Copy
 It looks like this:
 
 ```
-postgresql://username:password@ep-xxxxx-xxxxx.us-east-2.aws.neon.tech/neondb?sslmode=require
+postgresql://username:password@ep-xxxxx-xxxxx-pooler.us-east-2.aws.neon.tech/neondb?sslmode=require&channel_binding=require
 ```
 
 You can also find it anytime:
 
 1. Go to your project dashboard
-2. Click **Connection Details** in the sidebar
-3. Select your branch and database
-4. Copy the connection string
+2. Click the **Connect** button
+3. In the "Connect to your database" modal, select your branch, database, and role
+4. Copy the connection string (pooled by default -- note the `-pooler` in the host; toggle for a direct connection)
 
-> **Important:** Neon requires `sslmode=require`. Always include it in your connection string.
+> **Important:** Neon requires `sslmode=require`. Always include it in your connection string. The console also appends `channel_binding=require` -- fine for direct connections, but remove it when connecting through the `-pooler` host (PgBouncer does not support channel binding).
 
 ---
 
@@ -73,6 +73,8 @@ CREATE TABLE posts (
 );
 ```
 
+> **Tip:** In production, run schema migrations (Alembic, Prisma, drizzle-kit) from a CI job on push to `main` -- with the Neon URL in a repo secret -- instead of at app startup. This keeps serverless deploys migration-free and gives you a manual re-run button via `workflow_dispatch`.
+
 ---
 
 ## Use in Python (SQLAlchemy)
@@ -80,7 +82,7 @@ CREATE TABLE posts (
 ### Install Dependencies
 
 ```bash
-pip install sqlalchemy psycopg2-binary python-dotenv
+pip install sqlalchemy "psycopg[binary]" python-dotenv
 ```
 
 ### Connect with SQLAlchemy
@@ -91,7 +93,8 @@ from sqlalchemy import create_engine, Column, Integer, String, DateTime
 from sqlalchemy.orm import declarative_base, sessionmaker
 from datetime import datetime
 
-DATABASE_URL = os.environ["DATABASE_URL"]
+# SQLAlchemy defaults postgresql:// to psycopg2 -- point it at psycopg v3
+DATABASE_URL = os.environ["DATABASE_URL"].replace("postgresql://", "postgresql+psycopg://", 1)
 
 engine = create_engine(DATABASE_URL, echo=True)
 SessionLocal = sessionmaker(bind=engine)
@@ -141,7 +144,7 @@ from fastapi import FastAPI, Depends
 from sqlalchemy import create_engine, Column, Integer, String
 from sqlalchemy.orm import declarative_base, sessionmaker, Session
 
-DATABASE_URL = os.environ["DATABASE_URL"]
+DATABASE_URL = os.environ["DATABASE_URL"].replace("postgresql://", "postgresql+psycopg://", 1)
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine)
@@ -268,7 +271,8 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client-js"
+  provider = "prisma-client"
+  output   = "../generated/prisma"
 }
 
 model User {
@@ -279,13 +283,15 @@ model User {
 }
 ```
 
+> Prisma 7 deprecated the old `prisma-client-js` provider and requires the `output` field -- the client is generated into your project, not `node_modules`, and you import `PrismaClient` from that generated path.
+
 ```bash
 npx prisma db push    # Sync schema to database
 npx prisma generate   # Generate client
 ```
 
 ```js
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from './generated/prisma/client';
 
 const prisma = new PrismaClient();
 
@@ -311,17 +317,17 @@ await prisma.user.delete({ where: { email: 'sagar@example.com' } });
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `DATABASE_URL` | Neon connection string | `postgresql://user:pass@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require` |
+| `DATABASE_URL` | Neon connection string | `postgresql://user:pass@ep-xxx-pooler.us-east-2.aws.neon.tech/neondb?sslmode=require` |
 
 Set this on your deployment platform:
 
 - **Render:** Service > Environment tab > Add `DATABASE_URL`
 - **Vercel:** Project Settings > Environment Variables > Add `DATABASE_URL`
-- **Local:** Create a `.env` file (add `.env` to `.gitignore`)
+- **Local:** Create a `.env` file (add `.env` to `.gitignore`). Note: unlike Next.js, CLI tools like drizzle-kit and standalone scripts do not auto-load `.env.local` -- load it explicitly (`dotenv` in the config, or `tsx --env-file=.env.local`)
 
 ```bash
 # .env
-DATABASE_URL=postgresql://myuser:mypassword@ep-xxxxx-xxxxx.us-east-2.aws.neon.tech/neondb?sslmode=require
+DATABASE_URL=postgresql://myuser:mypassword@ep-xxxxx-xxxxx-pooler.us-east-2.aws.neon.tech/neondb?sslmode=require
 ```
 
 ---
@@ -330,18 +336,19 @@ DATABASE_URL=postgresql://myuser:mypassword@ep-xxxxx-xxxxx.us-east-2.aws.neon.te
 
 | Feature | Free Tier |
 |---------|-----------|
-| **Storage** | 0.5 GB |
-| **Compute hours** | 191 hours/month |
-| **Branches** | 10 |
-| **Projects** | 1 |
+| **Storage** | 0.5 GB per project |
+| **Compute** | 100 CU-hours/month per project |
+| **Branches** | 10 per project |
+| **Projects** | 100 |
 | **Autoscaling** | Up to 2 CU |
-| **History retention** | 24 hours |
+| **History retention** | 6 hours (capped at 1 GB-month) |
 
 Key details:
-- Compute suspends after 5 minutes of inactivity (automatic cold start on next query)
-- Cold start takes ~500ms-2s
-- The 191 compute hours are enough for hobby projects with intermittent traffic
+- Compute suspends after 5 minutes of inactivity (fixed on the free plan; automatic cold start on next query)
+- Cold start takes a few hundred milliseconds
+- 100 CU-hours run a 0.25 CU compute for ~400 hours/month -- plenty for hobby projects with intermittent traffic
 - Branching is a killer feature -- create instant copies of your database for testing
+- Paid plans are pay-as-you-go with no monthly minimum: Launch bills $0.106/CU-hour compute + $0.35/GB-month storage; Scale bills $0.222/CU-hour
 
 ---
 
@@ -407,23 +414,33 @@ engine = create_engine(
 
 **Fix:**
 
-1. Use connection pooling. Neon provides a built-in pooler -- change the port in your connection string:
+1. Use connection pooling. Neon provides a built-in PgBouncer pooler (transaction mode, up to 10,000 concurrent connections) -- append `-pooler` to the endpoint ID in the hostname, port stays 5432:
    - Direct connection: `ep-xxxxx.us-east-2.aws.neon.tech:5432`
-   - Pooled connection: `ep-xxxxx.us-east-2.aws.neon.tech:5432` with `-pooler` suffix on the host
-2. In the Neon console, go to **Connection Details** and check **Pooled connection**
-3. Use the pooled connection string in serverless environments (Vercel, AWS Lambda)
+   - Pooled connection: `ep-xxxxx-pooler.us-east-2.aws.neon.tech:5432`
+2. In the Neon console, click **Connect** on the project dashboard -- the connection string is pooled by default, with a toggle for a direct connection
+3. Use the pooled connection string in serverless environments (Vercel, AWS Lambda), and drop `channel_binding=require` from it (PgBouncer does not support channel binding)
+4. For read-mostly serverless workloads (single queries, no transactions), skip TCP pooling entirely: the `@neondatabase/serverless` driver's `neon()` HTTP client is the fastest path for one-shot queries and is safe to export as a module-level singleton -- each warm instance reuses one client
 
 ### Problem: Slow first query after inactivity
 
-**Cause:** Compute endpoint was suspended. Cold start takes 500ms-2s.
+**Cause:** Compute endpoint was suspended. It reactivates automatically within a few hundred milliseconds of the next query. If the branch has been idle for more than 24 hours, Neon may also archive it, and unarchiving adds a 15-25 s cold start on the next real request.
 
 **Fix:** This is expected on the free tier. Options:
 1. Accept cold starts for hobby projects
 2. Upgrade to a paid plan and disable suspension
 3. Use Neon's connection pooler which handles wake-up more gracefully
+4. Keep the branch warm with a scheduled GitHub Actions ping against an unauthenticated health endpoint:
 
-### Problem: Cannot create more than 1 project on free tier
+```yaml
+# .github/workflows/keepalive.yml
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl --silent --max-time 30 https://<your-backend>/health || echo "ignoring"
+```
 
-**Cause:** Free tier is limited to 1 project.
-
-**Fix:** Use **branches** within a single project. Branches are free (up to 10) and give you isolated database copies -- perfect for dev/staging environments.
+This costs ~0 Actions minutes and under 1% of the free CU-hours, and the `|| echo` keeps the job green even when the endpoint returns a non-200.

--- a/guides/netlify.md
+++ b/guides/netlify.md
@@ -8,7 +8,7 @@ Netlify is a platform for building and deploying modern web projects. It excels 
 
 - [ ] A [Netlify account](https://app.netlify.com/signup) (sign up with GitHub recommended)
 - [ ] [Git](https://git-scm.com/downloads) installed locally
-- [ ] [Node.js 18+](https://nodejs.org/)
+- [ ] [Node.js 22+](https://nodejs.org/)
 - [ ] (Optional) [Netlify CLI](https://docs.netlify.com/cli/get-started/): `npm i -g netlify-cli`
 
 ---
@@ -58,14 +58,14 @@ git push -u origin main
 ### Step 3: Import in Netlify
 
 1. Go to [app.netlify.com](https://app.netlify.com/)
-2. Click **Add new site** > **Import an existing project**
+2. Click **Add new project** > **Import an existing project**
 3. Select **GitHub** and authorize Netlify
 4. Choose your `my-static-site` repository
 5. Configure build settings:
    - **Branch to deploy:** `main`
    - **Build command:** (leave empty for plain HTML)
    - **Publish directory:** `.` (or your output folder)
-6. Click **Deploy site**
+6. Click **Publish**
 
 Your site is live in seconds at a URL like `https://random-name-123.netlify.app`.
 
@@ -157,7 +157,7 @@ Create `netlify.toml` in your project root for full build and deploy configurati
   functions = "netlify/functions"
 
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22"
 
 # Production context
 [context.production]
@@ -269,17 +269,25 @@ export default async (req, context) => {
 Create `netlify/functions/daily-cleanup.js`:
 
 ```js
-import { schedule } from '@netlify/functions';
-
-const handler = async (event) => {
+export default async (req) => {
   console.log('Running daily cleanup...');
   // Your cleanup logic here
-  return { statusCode: 200 };
 };
 
 // Run every day at midnight UTC
-export default schedule('0 0 * * *', handler);
+export const config = {
+  schedule: '0 0 * * *',
+};
 ```
+
+Or declare the schedule in `netlify.toml`:
+
+```toml
+[functions."daily-cleanup"]
+  schedule = "@daily"
+```
+
+> **Note:** Scheduled functions have a 30-second execution limit. For longer jobs, use a background function instead.
 
 ---
 
@@ -348,14 +356,14 @@ export const config = {
 | `API_SECRET_KEY` | Secret API key (server only) | `sk_live_abc123` |
 | `VITE_API_URL` | Public API URL (Vite apps) | `https://api.example.com` |
 | `NEXT_PUBLIC_API_URL` | Public API URL (Next.js) | `https://api.example.com` |
-| `NODE_VERSION` | Node.js version for builds | `20` |
+| `NODE_VERSION` | Node.js version for builds | `22` |
 | `NPM_FLAGS` | Custom npm flags | `--legacy-peer-deps` |
 | `SITE_URL` | Site URL (auto-set by Netlify) | `https://your-site.netlify.app` |
 
 ### Set via Dashboard
 
-1. Go to your site on [app.netlify.com](https://app.netlify.com/)
-2. Navigate to **Site configuration** > **Environment variables**
+1. Go to your project on [app.netlify.com](https://app.netlify.com/)
+2. Navigate to **Project configuration** > **Environment variables** (team-shared variables live under **Team settings** > **Environment variables**)
 3. Click **Add a variable**
 4. Enter the key and value
 5. Choose scopes: **All**, **Builds**, **Functions**, **Post processing**
@@ -393,7 +401,9 @@ netlify env:import .env
 
 ## Netlify Forms
 
-Netlify Forms handles form submissions without any server-side code. Add a `netlify` attribute to any HTML form and Netlify captures submissions automatically.
+Netlify Forms handles form submissions without any server-side code. On credit-based plans, submissions are free and unlimited.
+
+> **Required first step:** Form detection is off by default. In the Netlify UI, go to **Forms** and select **Enable form detection** -- only deploys after enabling are scanned for `data-netlify` forms. Then add a `netlify` attribute to any HTML form and Netlify captures submissions automatically.
 
 ### Basic Form
 
@@ -481,7 +491,7 @@ function ContactForm() {
 1. Go to your site on Netlify
 2. Navigate to **Forms** in the sidebar
 3. View, export, or delete submissions
-4. Set up email notifications under **Site configuration** > **Forms** > **Form notifications**
+4. Set up email notifications under **Project configuration** > **Forms** > **Form notifications**
 
 ---
 
@@ -550,21 +560,22 @@ Netlify shows the required DNS records. You have two options:
 **Option A: Use Netlify DNS (recommended)**
 
 1. In **Domain management**, click **Set up Netlify DNS**
-2. Netlify provides nameservers (e.g., `dns1.p01.nsone.net`)
-3. Update your domain registrar to use Netlify's nameservers:
-
-| Nameserver |
-|------------|
-| `dns1.p01.nsone.net` |
-| `dns2.p01.nsone.net` |
-| `dns3.p01.nsone.net` |
-| `dns4.p01.nsone.net` |
+2. Netlify assigns four nameservers to your domain -- make note of the ones listed in the **Name servers** panel (assignments vary per domain, so do not copy values from another site)
+3. Update your domain registrar to use those four nameservers
 
 **Option B: External DNS**
 
 Add these records at your DNS provider:
 
 **For apex domain (`yourdomain.com`):**
+
+Preferred: an ALIAS, ANAME, or flattened CNAME record (if your DNS provider supports one):
+
+| Type | Name | Value |
+|------|------|-------|
+| ALIAS / ANAME | @ | `apex-loadbalancer.netlify.com` |
+
+Fallback (less resilient, worse CDN routing) if your provider only supports A records:
 
 | Type | Name | Value |
 |------|------|-------|
@@ -589,30 +600,34 @@ To force HTTPS:
 
 ## Free Tier
 
-Netlify's free tier is generous for personal and small projects:
+Netlify moved to credit-based pricing on 2025-09-04 for new accounts. Instead of separate bandwidth and build-minute quotas, each plan grants a monthly pool of credits that all usage draws from:
 
-| Feature | Free (Starter) | Pro ($19/mo per member) |
-|---------|-----------------|-------------------------|
-| **Bandwidth** | 100 GB/month | 1 TB/month |
-| **Build minutes** | 300 min/month | 25,000 min/month |
-| **Serverless functions** | 125,000 requests/month | 2M requests/month |
-| **Function runtime** | 10 seconds max | 26 seconds max |
-| **Edge functions** | 3M invocations/month | 3M invocations/month |
-| **Forms** | 100 submissions/month | 1,000 submissions/month |
-| **Identity** | 1,000 active users | 1,000 active users |
-| **Analytics** | Not included | Included |
-| **Deploy previews** | Unlimited | Unlimited |
-| **Concurrent builds** | 1 | 3 |
-| **Team members** | 1 | Unlimited |
+| Feature | Free | Personal ($9/mo) | Pro ($20/mo, flat) |
+|---------|------|------------------|--------------------|
+| **Credits** | 300/month | 1,000/month | 3,000/month |
+| **Team members** | 1 | 1 | Unlimited |
+| **Forms** | Free, unlimited | Free, unlimited | Free, unlimited |
+| **Identity active users** | Unlimited | Unlimited | Unlimited |
+| **Deploy previews** | Unlimited | Unlimited | Unlimited |
+| **Extra credits** | Not purchasable | Purchasable | Purchasable |
+
+Credit consumption rates:
+
+| Usage | Credits |
+|-------|---------|
+| Production deploy | 15 each |
+| Bandwidth | 20 per GB |
+| Compute (functions + build time) | 10 per GB-hour |
+| Web requests | 2 per 10,000 |
 
 ### Key things to know:
 
-- **The free tier is always-on.** Static sites do not spin down or sleep.
+- **Sites do not sleep for inactivity**, but if your team exhausts its monthly credits, all projects on the team are paused (no web requests, form submissions, or production deploys) and visitors see a "Site not available" page. On the Free plan you cannot buy extra credits -- you wait for the next billing cycle or upgrade.
 - **Deploy previews are unlimited.** Every pull request gets a unique preview URL at no cost.
-- **Build minutes are shared** across all sites in your account. 300 minutes goes quickly with frequent deploys.
-- **Serverless functions have a 10-second timeout** on the free tier. Optimize long-running operations.
-- **Forms are limited to 100 submissions/month.** Use a third-party service (e.g., Formspree) if you need more.
-- **Bandwidth overages** are billed at $55 per 100 GB on the free plan. Monitor usage under **Site configuration** > **Usage**.
+- **Build minutes are no longer a separate metric.** Build time counts as compute GB-hours against your credits. An extra concurrent build is a $40/mo add-on.
+- **Serverless functions have a 60-second synchronous timeout** on all plans (not configurable). Scheduled functions get 30 seconds; background functions get 15 minutes.
+- **Forms are free and unlimited** on credit-based plans.
+- **Legacy plans** (accounts created before 2025-09-04) keep the old metered limits: 100 GB bandwidth, 300 build minutes, 125K function requests, $19/mo-per-member Pro, and $55/100 GB overage. Monitor usage under **Project configuration** > **Usage**.
 
 ---
 
@@ -628,13 +643,13 @@ Netlify's free tier is generous for personal and small projects:
 
 ```toml
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22"
 ```
 
-Or create a `.node-version` file:
+Or create a `.node-version` (or `.nvmrc`) file, which Netlify auto-detects:
 
 ```
-20
+22
 ```
 
 2. Clear the build cache and redeploy:
@@ -679,9 +694,9 @@ Or in `netlify.toml`:
 
 > **Important:** The SPA redirect must be the LAST redirect rule because Netlify processes redirects in order and stops at the first match.
 
-### Problem: Serverless function timeout (10-second limit)
+### Problem: Serverless function timeout (60-second limit)
 
-**Cause:** The function exceeds the 10-second execution limit on the free tier.
+**Cause:** The function exceeds the 60-second synchronous execution limit (applies on all plans and is not configurable).
 
 **Fix:**
 
@@ -706,15 +721,18 @@ export default async (req, context) => {
 };
 ```
 
-2. For long-running operations, use Netlify Background Functions (Pro plan):
+2. For long-running operations, use Netlify Background Functions (available on all plans, up to 15 minutes):
 
 ```js
-// netlify/functions/long-task-background.js
-// The "-background" suffix makes it a background function (up to 15 minutes)
+// netlify/functions/long-task.js
 export default async (req, context) => {
   // Long-running task here
   await processLargeDataset();
-  return { statusCode: 200 };
+};
+
+// Marks this as a background function (up to 15 minutes)
+export const config = {
+  background: true,
 };
 ```
 
@@ -722,17 +740,19 @@ export default async (req, context) => {
 
 ### Problem: Netlify Forms submissions not appearing
 
-**Cause:** The form is not detected during the build, the `data-netlify="true"` attribute is missing, or the hidden `form-name` input is missing.
+**Cause:** Form detection is not enabled (it is off by default), the form is not detected during the build, the `data-netlify="true"` attribute is missing, or the hidden `form-name` input is missing.
 
 **Fix:**
 
-1. Ensure the form has `data-netlify="true"`:
+1. Enable form detection: in the Netlify UI, go to **Forms** and select **Enable form detection**, then redeploy. Only deploys after enabling are scanned for forms. This is the most common cause.
+
+2. Ensure the form has `data-netlify="true"`:
 
 ```html
 <form name="contact" method="POST" data-netlify="true">
 ```
 
-2. For SPAs (React, Vue), add a hidden HTML form in `public/index.html` so Netlify can detect it at build time:
+3. For SPAs (React, Vue), add a hidden HTML form in `public/index.html` so Netlify can detect it at build time:
 
 ```html
 <form name="contact" data-netlify="true" hidden>
@@ -742,7 +762,7 @@ export default async (req, context) => {
 </form>
 ```
 
-3. Include the hidden `form-name` field in your JavaScript form submission:
+4. Include the hidden `form-name` field in your JavaScript form submission:
 
 ```js
 const formData = new URLSearchParams({
@@ -759,7 +779,7 @@ await fetch('/', {
 });
 ```
 
-4. Check form submissions in the Netlify dashboard under **Forms**
+5. Check form submissions in the Netlify dashboard under **Forms**
 
 ### Problem: Deploy previews show wrong content or fail
 
@@ -768,7 +788,7 @@ await fetch('/', {
 **Fix:**
 
 1. Ensure environment variables are available in the deploy-preview context:
-   - Go to **Site configuration** > **Environment variables**
+   - Go to **Project configuration** > **Environment variables**
    - Set the variable scope to include **Deploy previews**
 
 2. Use `netlify.toml` to set context-specific build commands:
@@ -808,22 +828,20 @@ await fetch('/', {
 /*            /index.html                  200
 ```
 
-3. Use the Netlify [redirect playground](https://play.netlify.com/redirects) to test your rules
-
-4. Check redirect behavior with the CLI:
+3. Check redirect behavior with the CLI:
 
 ```bash
 netlify dev
 # Visit http://localhost:8888 and test your redirects locally
 ```
 
-### Problem: Large site exceeds bandwidth on the free tier
+### Problem: Site paused after burning through free-tier credits
 
-**Cause:** The 100 GB monthly bandwidth limit is reached, often due to large assets or high traffic.
+**Cause:** The 300 monthly credits are exhausted, often due to bandwidth (20 credits/GB, so roughly 15 GB/month effective) from large assets or high traffic. When credits run out, all projects on the team are paused and visitors see a "Site not available" page. On the Free plan you cannot buy extra credits -- you wait for the next billing cycle or upgrade.
 
 **Fix:**
 
-1. Check bandwidth usage under **Site configuration** > **Usage**
+1. Check credit usage under **Project configuration** > **Usage**
 
 2. Optimize assets:
 
@@ -850,4 +868,4 @@ npx sharp-cli --input "src/images/*.{jpg,png}" --output "src/images/optimized" -
 
 4. Use a CDN like Cloudflare in front of Netlify to reduce bandwidth from Netlify's perspective
 
-5. Upgrade to the Pro plan ($19/month) for 1 TB bandwidth if needed
+5. Upgrade to the Personal plan ($9/month, 1,000 credits) or Pro plan ($20/month, 3,000 credits) if needed

--- a/guides/railway.md
+++ b/guides/railway.md
@@ -2,15 +2,15 @@
 
 > Deploy backend apps and databases instantly with Railway's Git-based workflow and managed infrastructure.
 
-Railway is a modern cloud platform that simplifies deploying web applications and provisioning databases. It supports automatic builds via Nixpacks, GitHub-based deployments, built-in PostgreSQL and Redis add-ons, and a usage-based billing model. Railway handles Dockerfiles, Nixpacks auto-detection, and `railway.toml` configuration for fine-grained control.
+Railway is a modern cloud platform that simplifies deploying web applications and provisioning databases. It supports automatic builds via Railpack (the default builder since 2025-09-19), GitHub-based deployments, built-in PostgreSQL and Redis add-ons, and a usage-based billing model. Railway handles Dockerfiles, Railpack auto-detection, and `railway.toml` configuration for fine-grained control.
 
 ## Prerequisites
 
-- [ ] A [Railway account](https://railway.app/) (sign up with GitHub recommended)
+- [ ] A [Railway account](https://railway.com/) (sign up with GitHub recommended)
 - [ ] [Git](https://git-scm.com/downloads) installed locally
-- [ ] [Node.js 18+](https://nodejs.org/) (for Node.js/Express projects)
-- [ ] [Python 3.9+](https://www.python.org/downloads/) (for FastAPI projects)
-- [ ] (Optional) [Railway CLI](https://docs.railway.app/guides/cli): `npm i -g @railway/cli`
+- [ ] [Node.js 22+](https://nodejs.org/) (for Node.js/Express projects)
+- [ ] [Python 3.10+](https://www.python.org/downloads/) (3.13 recommended, for FastAPI projects)
+- [ ] (Optional) [Railway CLI](https://docs.railway.com/guides/cli): `npm i -g @railway/cli`
 
 ---
 
@@ -49,7 +49,7 @@ Create `package.json`:
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.0"
+    "express": "^5.2.1"
   }
 }
 ```
@@ -69,10 +69,10 @@ git push -u origin main
 
 ### Step 3: Deploy via Dashboard
 
-1. Go to [railway.app/new](https://railway.app/new)
+1. Go to [railway.com/new](https://railway.com/new)
 2. Click **Deploy from GitHub repo**
 3. Select your `my-express-app` repository
-4. Railway auto-detects Node.js via Nixpacks -- no configuration needed
+4. Railway auto-detects Node.js via Railpack -- no configuration needed
 5. Click **Deploy Now**
 
 Railway builds and deploys your app. Click **Generate Domain** under the service settings to get a public URL like `https://my-express-app-production.up.railway.app`.
@@ -122,21 +122,24 @@ def health_check():
 Create `requirements.txt`:
 
 ```
-fastapi==0.109.0
-uvicorn[standard]==0.27.0
+fastapi==0.139.0
+uvicorn[standard]==0.50.1
 ```
 
 ### Step 2: Configure the Start Command
 
-Railway uses Nixpacks to detect Python projects. You can specify the start command in a `railway.toml` or `Procfile`.
+Railway uses Railpack to detect Python projects. When `fastapi` and `uvicorn` are in your dependencies, Railpack auto-detects FastAPI and starts it with `uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}` -- no extra configuration needed.
 
-Create `Procfile`:
+To override the start command, set it in `railway.toml`:
 
+```toml
+[deploy]
+startCommand = "uvicorn main:app --host 0.0.0.0 --port $PORT"
 ```
-web: uvicorn main:app --host 0.0.0.0 --port $PORT
-```
 
-Or set the start command in the Railway dashboard under your service's **Settings** > **Deploy** > **Custom Start Command**.
+Or set it in the Railway dashboard under your service's **Settings** > **Deploy** > **Custom Start Command**.
+
+> **Note:** `Procfile` still works under Railpack but is officially deprecated. Prefer `railway.toml`, `railpack.json`, or the dashboard setting.
 
 ### Step 3: Push to GitHub and Deploy
 
@@ -200,22 +203,24 @@ Create `railway.toml` in your project root for build and deploy configuration:
 
 ```toml
 [build]
-builder = "nixpacks"
+builder = "RAILPACK"
 buildCommand = "npm run build"
 
 [deploy]
 startCommand = "npm start"
 healthcheckPath = "/health"
 healthcheckTimeout = 100
-restartPolicyType = "on_failure"
+restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 5
 ```
+
+> **Note:** Builder and restart policy values are uppercase: `RAILPACK` (default), `DOCKERFILE`, or `NIXPACKS` (legacy); `ON_FAILURE`, `ALWAYS`, or `NEVER`. Config can also live in `railway.json` instead of `railway.toml`.
 
 ### Python Example
 
 ```toml
 [build]
-builder = "nixpacks"
+builder = "RAILPACK"
 buildCommand = "pip install -r requirements.txt"
 
 [deploy]
@@ -224,22 +229,25 @@ healthcheckPath = "/health"
 healthcheckTimeout = 100
 ```
 
-### Nixpacks Configuration
+### Railpack Configuration
 
-Railway uses [Nixpacks](https://nixpacks.com/) to auto-detect and build your app. Nixpacks supports Node.js, Python, Go, Rust, Java, and many other languages. You can customize the build with a `nixpacks.toml`:
+Railway uses [Railpack](https://railpack.com/) (the default builder since 2025-09-19, replacing Nixpacks) to auto-detect and build your app. Railpack supports Node.js, Python, Go, Rust, Java, PHP, and many other languages, and for Python it detects pip, uv, poetry, pdm, and pipenv. You can customize the build with a `railpack.json`:
 
-```toml
-[phases.setup]
-nixPkgs = ["...", "ffmpeg"]
-
-[phases.install]
-cmds = ["npm ci"]
-
-[phases.build]
-cmds = ["npm run build"]
-
-[start]
-cmd = "npm start"
+```json
+{
+  "$schema": "https://schema.railpack.com",
+  "steps": {
+    "install": {
+      "commands": ["npm ci"]
+    },
+    "build": {
+      "commands": ["npm run build"]
+    }
+  },
+  "deploy": {
+    "startCommand": "npm start"
+  }
+}
 ```
 
 ---
@@ -249,15 +257,15 @@ cmd = "npm start"
 ### Add PostgreSQL
 
 1. Open your project on the Railway dashboard
-2. Click **New** > **Database** > **Add PostgreSQL**
-3. Railway provisions a PostgreSQL instance and sets `DATABASE_URL` automatically
-4. Your app can access the database via `DATABASE_URL`
+2. Click **+ New** on the Project Canvas (or press ctrl/cmd+K) and pick **PostgreSQL**
+3. Railway provisions a PostgreSQL instance and sets `DATABASE_URL` on the database service
+4. In your app service's **Variables** tab, add a reference variable so your app can read it: `DATABASE_URL=${{Postgres.DATABASE_URL}}`
 
 Via CLI:
 
 ```bash
 # Add PostgreSQL to your project
-railway add --plugin postgresql
+railway add --database postgres
 
 # Connect to the database locally
 railway connect postgres
@@ -266,14 +274,15 @@ railway connect postgres
 ### Add Redis
 
 1. Open your project on the Railway dashboard
-2. Click **New** > **Database** > **Add Redis**
-3. Railway provisions a Redis instance and sets `REDIS_URL` automatically
+2. Click **+ New** on the Project Canvas (or press ctrl/cmd+K) and pick **Redis**
+3. Railway provisions a Redis instance and sets `REDIS_URL` on the database service
+4. In your app service's **Variables** tab, add a reference variable: `REDIS_URL=${{Redis.REDIS_URL}}`
 
 Via CLI:
 
 ```bash
 # Add Redis to your project
-railway add --plugin redis
+railway add --database redis
 
 # Connect to Redis locally
 railway connect redis
@@ -314,16 +323,16 @@ async def connect():
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `PORT` | Server port (auto-set by Railway) | `3000` |
-| `DATABASE_URL` | PostgreSQL connection string (auto-set if plugin added) | `postgresql://user:pass@host/db` |
-| `REDIS_URL` | Redis connection string (auto-set if plugin added) | `redis://default:pass@host:6379` |
-| `RAILWAY_ENVIRONMENT` | Current environment name | `production` |
+| `DATABASE_URL` | PostgreSQL connection string (reference it from the database service: `${{Postgres.DATABASE_URL}}`) | `postgresql://user:pass@host/db` |
+| `REDIS_URL` | Redis connection string (reference it from the database service: `${{Redis.REDIS_URL}}`) | `redis://default:pass@host:6379` |
+| `RAILWAY_ENVIRONMENT_NAME` | Current environment name | `production` |
 | `RAILWAY_PUBLIC_DOMAIN` | Public domain of the service | `my-app-production.up.railway.app` |
 | `NODE_ENV` | Node environment | `production` |
 | `SECRET_KEY` | App secret key | `your-secret-key-here` |
 
 ### Set via Dashboard
 
-1. Go to your project on [railway.app](https://railway.app/)
+1. Go to your project on [railway.com](https://railway.com/)
 2. Click on your service
 3. Navigate to the **Variables** tab
 4. Click **New Variable** and enter key-value pairs
@@ -366,25 +375,27 @@ Railway supports shared variables across services in a project. Set them at the 
 
 ### Step 3: Configure DNS
 
-Add the DNS records shown by Railway at your domain registrar:
+Railway shows two DNS records when you add a custom domain: a CNAME record pointing at a Railway-provided endpoint (e.g., `g05ns7.up.railway.app`) and a TXT record used to verify domain ownership. Add both at your domain registrar -- the domain will not verify with only the CNAME in place.
 
 **For subdomain (`api.yourdomain.com`):**
 
 | Type | Name | Value |
 |------|------|-------|
-| CNAME | api | `<your-service>.up.railway.app` |
+| CNAME | api | `<railway-provided-endpoint>.up.railway.app` |
+| TXT | (as shown by Railway) | (verification value from the dashboard) |
 
 **For apex domain (`yourdomain.com`):**
 
 | Type | Name | Value |
 |------|------|-------|
-| CNAME | @ | `<your-service>.up.railway.app` |
+| CNAME | @ | `<railway-provided-endpoint>.up.railway.app` |
+| TXT | (as shown by Railway) | (verification value from the dashboard) |
 
-> **Note:** Some DNS providers do not support CNAME records on the apex domain. In that case, use a CNAME-flattening provider (e.g., Cloudflare) or use a subdomain like `www`.
+> **Note:** Some DNS providers do not support CNAME records on the apex domain. In that case, use a CNAME-flattening provider (e.g., Cloudflare), an ALIAS/ANAME record, or use a subdomain like `www`.
 
 ### Step 4: Verify and SSL
 
-Railway automatically provisions an SSL certificate via Let's Encrypt once DNS propagates. No manual configuration is needed. Verification typically completes in a few minutes.
+Railway automatically provisions an SSL certificate via Let's Encrypt (RSA 2048, 90-day certificates auto-renewed at 30 days remaining) once DNS propagates. No manual configuration is needed. Certificate issuance should happen within an hour of your DNS being updated; DNS propagation itself can take up to 72 hours depending on your provider.
 
 ---
 
@@ -392,21 +403,21 @@ Railway automatically provisions an SSL certificate via Let's Encrypt once DNS p
 
 Railway uses usage-based billing with a trial credit:
 
-| Feature | Trial Plan | Hobby ($5/mo) | Pro ($20/mo) |
-|---------|------------|----------------|--------------|
-| **Credit** | $5 one-time | $5/month included | $20/month included |
-| **Execution Hours** | 500 hours total | Unlimited | Unlimited |
-| **Memory** | Up to 512 MB | Up to 8 GB | Up to 32 GB |
-| **Shared CPU** | Yes | Up to 8 vCPU | Up to 32 vCPU |
-| **Network** | 100 GB egress | 100 GB egress | Unlimited |
-| **Services** | Limited | Unlimited | Unlimited |
-| **Always-On** | Yes (while credits last) | Yes | Yes |
+| Feature | Free Plan | Trial Plan | Hobby ($5/mo) | Pro ($20/seat/mo) |
+|---------|-----------|------------|----------------|--------------|
+| **Credit** | $1/month | $5 one-time (expires in 30 days) | $5/month included | $20/month included |
+| **Memory** | Up to 0.5 GB | Up to 1 GB | Up to 48 GB | Up to 1 TB |
+| **Shared CPU** | 1 vCPU | 2 vCPU | Up to 48 vCPU | Up to 1,000 vCPU |
+| **Network** | Usage-billed ($0.05/GB egress) | Usage-billed ($0.05/GB egress) | Usage-billed ($0.05/GB egress) | Usage-billed ($0.05/GB egress) |
+| **Services** | Limited | 5 per project, 2 replicas | Unlimited | Unlimited |
+| **Always-On** | Yes (while credits last) | Yes (while credits last) | Yes | Yes |
 
 ### Key things to know:
 
-- **Trial gives $5 in free credit.** Once credits are exhausted, services stop until you add a payment method.
+- **Trial gives a one-time $5 credit, no credit card required.** Credits expire in 30 days. After 30 days pass or the $5 is spent, the account reverts to the Free plan ($1 of free credit per month).
+- **When your credit balance reaches zero, workloads are stopped** until you add credits or upgrade.
 - **Railway does NOT spin down free services.** Unlike Render, services are always-on while credits last.
-- **Usage is billed per minute** based on CPU and memory consumption. Idle services still use a small amount of resources.
+- **Usage is billed per second** based on CPU and memory consumption. Idle services still use a small amount of resources.
 - **The Hobby plan** ($5/month) is the lowest paid tier and includes $5 of usage credit. Most small apps cost well under $5/month.
 - Monitor your credit usage in the dashboard under **Usage**.
 
@@ -414,28 +425,24 @@ Railway uses usage-based billing with a trial credit:
 
 ## Troubleshooting
 
-### Problem: Build fails with Nixpacks
+### Problem: Build fails with Railpack
 
-**Cause:** Nixpacks cannot detect your project type or a dependency is missing.
+**Cause:** Railpack cannot detect your project type or a dependency is missing.
 
 **Fix:**
 
 ```bash
 # Make sure your project has the correct files for detection:
 # Node.js: package.json must exist
-# Python: requirements.txt or Pipfile must exist
+# Python: requirements.txt, pyproject.toml, or uv.lock must exist
 
-# Test the Nixpacks build locally
-npx nixpacks build . --name test-build
-
-# If Nixpacks detection fails, specify the builder explicitly in railway.toml:
+# If detection fails, specify the builder explicitly in railway.toml:
 ```
 
 ```toml
 # railway.toml
 [build]
-builder = "nixpacks"
-nixpacksPlan = { providers = ["node"] }
+builder = "RAILPACK"
 ```
 
 Or switch to a Dockerfile-based build:
@@ -443,7 +450,7 @@ Or switch to a Dockerfile-based build:
 ```toml
 # railway.toml
 [build]
-builder = "dockerfile"
+builder = "DOCKERFILE"
 dockerfilePath = "./Dockerfile"
 ```
 
@@ -474,11 +481,11 @@ railway logs
 
 ### Problem: Database connection refused
 
-**Cause:** The app is using a hardcoded connection string instead of the `DATABASE_URL` variable, or the database plugin has not been added.
+**Cause:** The app is using a hardcoded connection string instead of the `DATABASE_URL` variable, the database service has not been added, or the reference variable is missing on the app service.
 
 **Fix:**
 
-1. Verify the PostgreSQL plugin is added to your project (check the dashboard)
+1. Verify the PostgreSQL service is added to your project (check the dashboard)
 2. Ensure your app reads `DATABASE_URL` from the environment:
 
 ```js
@@ -496,7 +503,7 @@ DATABASE_URL = os.environ.get("DATABASE_URL")
 ```
 
 3. Check that the variable is visible in the **Variables** tab of your service
-4. Railway auto-injects database variables into linked services. If the variable is missing, go to the database service and copy the connection string manually
+4. Railway does NOT auto-inject database variables into other services. Add a reference variable on your app service, e.g. `DATABASE_URL=${{Postgres.DATABASE_URL}}`, so it resolves from the database service
 
 ### Problem: Credits running out too fast
 
@@ -513,8 +520,8 @@ DATABASE_URL = os.environ.get("DATABASE_URL")
 NODE_OPTIONS=--max-old-space-size=256
 ```
 
-4. Use Railway's sleep feature for development environments:
-   - Go to service **Settings** > enable **Sleep** to pause the service when not in use
+4. Use Railway's Serverless feature (formerly App Sleeping) for development environments:
+   - Go to service **Settings** > **Deploy** > enable **Enable Serverless**. Railway stops the service after it sends no outbound traffic for at least 10 minutes. In config-as-code this is `deploy.sleepApplication`
 5. Upgrade to the Hobby plan ($5/month) which includes $5 of usage credit each month
 
 ### Problem: Service shows "No active deployment" or fails to start
@@ -525,7 +532,7 @@ NODE_OPTIONS=--max-old-space-size=256
 
 1. Check that your `railway.toml` or dashboard settings have the correct start command
 2. For Node.js, ensure `package.json` has a `start` script
-3. For Python, ensure a `Procfile` or explicit start command is set
+3. For Python, ensure an explicit start command is set (in `railway.toml`, `railpack.json`, or the dashboard -- `Procfile` still works but is deprecated)
 4. Check the build logs for errors:
 
 ```bash

--- a/guides/render.md
+++ b/guides/render.md
@@ -8,8 +8,8 @@ Render is a cloud platform that supports web services, static sites, cron jobs, 
 
 - [ ] A [Render account](https://render.com/) (sign up with GitHub recommended)
 - [ ] [Git](https://git-scm.com/downloads) installed locally
-- [ ] [Node.js 18+](https://nodejs.org/) (for Node.js/Express projects)
-- [ ] [Python 3.9+](https://www.python.org/downloads/) (for FastAPI projects)
+- [ ] [Node.js 22+](https://nodejs.org/) (for Node.js/Express projects)
+- [ ] [Python 3.12+](https://www.python.org/downloads/) (for FastAPI projects)
 
 ---
 
@@ -43,12 +43,14 @@ app.listen(PORT, () => {
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.0"
+    "express": "^5.2.0"
   }
 }
 ```
 
 > **Important:** Always use `process.env.PORT`. Render assigns the port dynamically.
+
+> **Tip:** Pin your Node version with a `.nvmrc` file (e.g. `22`) in the repo root. Render reads it to pick the build image; without it, new services default to Node 24.
 
 ### Step 2: Push to GitHub
 
@@ -68,7 +70,7 @@ git push -u origin main
 3. Connect your GitHub repository
 4. Configure:
    - **Name:** `my-express-app`
-   - **Runtime:** Node
+   - **Language:** Node
    - **Build Command:** `npm install`
    - **Start Command:** `npm start`
    - **Instance Type:** Free
@@ -101,9 +103,11 @@ def health_check():
 Create `requirements.txt`:
 
 ```
-fastapi==0.109.0
-uvicorn[standard]==0.27.0
+fastapi==0.139.0
+uvicorn[standard]==0.50.1
 ```
+
+> **Tip:** Pin your Python version with a `.python-version` file (e.g. `3.14`) in the repo root. Render reads it to pick the build image; without it, new services default to Python 3.14. Render also supports [uv](https://docs.astral.sh/uv/) natively -- it detects a `uv.lock` in the repo root (pin the uv version with the `UV_VERSION` env var).
 
 ### Step 2: Push to GitHub
 
@@ -123,7 +127,7 @@ git push -u origin main
 3. Connect your GitHub repository
 4. Configure:
    - **Name:** `my-fastapi-app`
-   - **Runtime:** Python
+   - **Language:** Python
    - **Build Command:** `pip install -r requirements.txt`
    - **Start Command:** `uvicorn main:app --host 0.0.0.0 --port $PORT`
    - **Instance Type:** Free
@@ -146,10 +150,10 @@ Your API docs are automatically available at `https://my-fastapi-app.onrender.co
 ### Set via Dashboard
 
 1. Go to your service on Render
-2. Navigate to **Environment** tab
-3. Click **Add Environment Variable**
+2. Click **Environment** in the left pane
+3. Click **+ Add Environment Variable** (or **Add from .env** to paste in bulk)
 4. Enter key-value pairs
-5. Click **Save Changes** (triggers a redeploy)
+5. Save with **Save, rebuild, and deploy** or **Save and deploy** (choose **Save only** to skip the redeploy)
 
 ### Set via render.yaml (Infrastructure as Code)
 
@@ -194,7 +198,9 @@ Add the DNS record shown by Render:
 
 | Type | Name | Value |
 |------|------|-------|
-| A | @ | (IP shown by Render) |
+| A | @ | `216.24.57.1` |
+
+> Use an ANAME/ALIAS record instead if your DNS provider supports it, and remove any AAAA records -- Render serves over IPv4 only.
 
 ### Step 3: Verify and SSL
 
@@ -211,7 +217,7 @@ Auto-deploy is enabled by default when you connect a GitHub repo. Every push to 
 If you want manual control:
 
 1. Go to your service **Settings**
-2. Under **Build & Deploy**, toggle off **Auto-Deploy**
+2. Under **Build & Deploy**, set the **Auto-Deploy** dropdown to **Off** (the other options are **On Commit** and **After CI Checks Pass**)
 
 ### Deploy Hooks
 
@@ -231,17 +237,17 @@ Render's free tier has important constraints:
 | Feature | Free Tier | Paid (Starter $7/mo) |
 |---------|-----------|----------------------|
 | **Spin-down** | Sleeps after 15 min of inactivity | Always on |
-| **Cold start** | ~30-60 seconds on first request | None |
+| **Cold start** | ~1 minute on first request | None |
 | **Hours** | 750 hours/month total across all free services | Unlimited |
-| **Bandwidth** | 100 GB/month | 100 GB/month |
+| **Bandwidth** | 5 GB/month per workspace (then $0.15/GB) | 5 GB/month per workspace (then $0.15/GB) |
 | **Build minutes** | 500 min/month | 500 min/month |
 
 ### Key things to know:
 
-- **Free services spin down after 15 minutes of no traffic.** The next request takes 30-60 seconds (cold start).
+- **Free services spin down after 15 minutes of no traffic.** The next request takes about a minute (cold start) while Render shows a loading page.
 - The 750 free hours are shared across ALL your free services. One service running 24/7 uses ~730 hours.
 - Free services are automatically suspended if you exceed limits.
-- Free PostgreSQL databases are deleted after 90 days.
+- Free PostgreSQL databases expire 30 days after creation, with a 14-day grace period to upgrade before Render deletes them. Max one free Postgres per workspace, 1 GB storage.
 
 ### Workaround for Spin-Down
 
@@ -252,7 +258,22 @@ Use an external cron to ping your service every 14 minutes (not recommended for 
 # Ping every 14 minutes: https://my-express-app.onrender.com/health
 ```
 
-Or upgrade to the Starter plan ($7/month) for always-on services.
+Or use a scheduled GitHub Actions workflow -- costs ~0 Actions minutes and never fails the job on a non-200:
+
+```yaml
+# .github/workflows/keepalive.yml
+name: Keep backend awake
+on:
+  schedule:
+    - cron: "*/14 * * * *"
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl --silent --max-time 30 https://my-express-app.onrender.com/health || echo "ignoring"
+```
+
+Note that keeping one service awake 24/7 uses ~730 of your 750 monthly free hours. Or upgrade to the Starter plan ($7/month) for always-on services.
 
 ---
 
@@ -295,7 +316,7 @@ app.listen(PORT);
 # Start command: uvicorn main:app --host 0.0.0.0 --port $PORT
 ```
 
-### Problem: First request is very slow (~30-60 seconds)
+### Problem: First request is very slow (~1 minute)
 
 **Cause:** Free tier spin-down. The service went to sleep after 15 minutes of inactivity.
 

--- a/guides/supabase.md
+++ b/guides/supabase.md
@@ -7,9 +7,9 @@ Supabase wraps a full PostgreSQL database with a suite of tools: automatic REST 
 ## Prerequisites
 
 - [ ] A [Supabase account](https://supabase.com/dashboard) (sign up with GitHub for easiest setup)
-- [ ] [Node.js 18+](https://nodejs.org/) (for JavaScript usage)
-- [ ] [Python 3.9+](https://www.python.org/downloads/) (for Python usage)
-- [ ] (Optional) [Supabase CLI](https://supabase.com/docs/guides/cli): `npm install -g supabase`
+- [ ] [Node.js 22+](https://nodejs.org/) (for JavaScript usage)
+- [ ] [Python 3.12+](https://www.python.org/downloads/) (for Python usage)
+- [ ] (Optional) [Supabase CLI](https://supabase.com/docs/guides/cli): `npm install supabase --save-dev` (then run with `npx supabase`)
 
 ---
 
@@ -31,17 +31,21 @@ The project takes about 2 minutes to provision. Once ready, you have a full Post
 ## Step 2: Get Your API Keys
 
 1. Go to your project dashboard
-2. Click **Settings** > **API** in the sidebar
+2. Click **Settings** > **API Keys** in the sidebar
 3. Copy these values:
 
 | Value | Where to Find | What It Is |
 |-------|---------------|------------|
-| **Project URL** | Settings > API | `https://<project-id>.supabase.co` |
-| **Anon (public) key** | Settings > API > Project API keys | Safe to use in browser code. Respects RLS policies. |
-| **Service role key** | Settings > API > Project API keys | **Server-only.** Bypasses RLS. Never expose to the client. |
-| **Connection string** | Settings > Database > Connection string | Direct Postgres connection: `postgresql://postgres:[password]@db.<project-id>.supabase.co:5432/postgres` |
+| **Project URL** | Settings > API Keys (or the Connect dialog) | `https://<project-id>.supabase.co` |
+| **Publishable key** (`sb_publishable_...`) | Settings > API Keys | Safe to use in browser code. Respects RLS policies. |
+| **Secret key** (`sb_secret_...`) | Settings > API Keys | **Server-only.** Bypasses RLS. Never expose to the client. Supabase blocks secret keys used from browsers. |
+| **Connection string** | **Connect** button at the top of the dashboard | Direct Postgres connection: `postgresql://postgres:[password]@db.<project-id>.supabase.co:5432/postgres` |
 
-> **Warning:** The service role key bypasses all Row Level Security. Only use it in server-side code, never in a browser or mobile app.
+> **Warning:** The secret key bypasses all Row Level Security. Only use it in server-side code, never in a browser or mobile app.
+
+> **Note:** Publishable and secret keys replace the legacy JWT-based `anon` and `service_role` keys. Projects created after November 2025 do not have the legacy keys at all; older projects keep them working alongside the new keys until Supabase removes them in late 2026. Migrate to the new keys.
+
+> **Note:** Direct connections (`db.<project-id>.supabase.co:5432`) are IPv6-only by default. On IPv4-only networks (many CI runners and hosts), use the Supavisor pooler connection string or the paid IPv4 add-on.
 
 ---
 
@@ -92,12 +96,12 @@ Both methods produce the same result. The SQL Editor is faster for complex schem
 
 ## Row Level Security (RLS)
 
-RLS is enabled by default on new tables in Supabase. Without policies, **no rows are accessible** via the API. You must create policies to allow access.
+RLS is enabled by default only on tables created with the **Table Editor**. Tables created in raw SQL or the **SQL Editor** (like the ones in Step 3) have RLS **disabled** until you enable it yourself -- until then, every row is exposed through the API. Once RLS is on, no rows are accessible without policies.
 
 ### Enable RLS and Add Policies
 
 ```sql
--- Enable RLS (already enabled by default on new tables)
+-- Enable RLS (required for tables created via SQL; Table Editor tables have it on already)
 ALTER TABLE posts ENABLE ROW LEVEL SECURITY;
 
 -- Allow anyone to read published posts
@@ -149,7 +153,7 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY
+  process.env.SUPABASE_PUBLISHABLE_KEY
 );
 ```
 
@@ -188,14 +192,14 @@ const { error: deleteError } = await supabase
 
 ### Server-Side Client (Bypasses RLS)
 
-For server-side operations that need full access, use the service role key:
+For server-side operations that need full access, use the secret key:
 
 ```js
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseAdmin = createClient(
   process.env.SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
+  process.env.SUPABASE_SECRET_KEY
 );
 
 // This bypasses RLS -- use only in trusted server environments
@@ -221,7 +225,7 @@ import os
 from supabase import create_client, Client
 
 url = os.environ["SUPABASE_URL"]
-key = os.environ["SUPABASE_ANON_KEY"]
+key = os.environ["SUPABASE_PUBLISHABLE_KEY"]
 
 supabase: Client = create_client(url, key)
 ```
@@ -264,7 +268,7 @@ from fastapi import FastAPI, HTTPException
 from supabase import create_client
 
 url = os.environ["SUPABASE_URL"]
-key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+key = os.environ["SUPABASE_SECRET_KEY"]
 supabase = create_client(url, key)
 
 app = FastAPI()
@@ -456,14 +460,16 @@ Supabase Realtime lets you listen for database changes over WebSockets.
 
 ### Enable Realtime on a Table
 
-1. Go to **Database** > **Replication**
-2. Enable replication for the tables you want to subscribe to
+1. Go to **Database** > **Publications**
+2. Toggle the tables you want to subscribe to under the `supabase_realtime` publication
 
 Or via SQL:
 
 ```sql
 ALTER PUBLICATION supabase_realtime ADD TABLE posts;
 ```
+
+> **Tip:** For high-traffic apps, Supabase recommends the Broadcast feature over `postgres_changes`, which does not scale as well.
 
 ### Subscribe to Changes (Node.js)
 
@@ -526,8 +532,8 @@ const channel = supabase
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `SUPABASE_URL` | Project API URL | `https://abcdefghij.supabase.co` |
-| `SUPABASE_ANON_KEY` | Public (anon) API key. Safe for client-side. Respects RLS. | `eyJhbGciOiJIUzI1NiIs...` |
-| `SUPABASE_SERVICE_ROLE_KEY` | Secret service role key. **Server-only.** Bypasses RLS. | `eyJhbGciOiJIUzI1NiIs...` |
+| `SUPABASE_PUBLISHABLE_KEY` | Publishable API key. Safe for client-side. Respects RLS. | `sb_publishable_...` |
+| `SUPABASE_SECRET_KEY` | Secret API key. **Server-only.** Bypasses RLS. | `sb_secret_...` |
 
 ### Set on Your Deployment Platform
 
@@ -539,11 +545,11 @@ const channel = supabase
 ```bash
 # .env
 SUPABASE_URL=https://abcdefghij.supabase.co
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+SUPABASE_PUBLISHABLE_KEY=sb_publishable_...
+SUPABASE_SECRET_KEY=sb_secret_...
 ```
 
-> **Important:** Only use `SUPABASE_ANON_KEY` in client-side code. The `SUPABASE_SERVICE_ROLE_KEY` must only be used in server-side environments.
+> **Important:** Only use `SUPABASE_PUBLISHABLE_KEY` in client-side code. The `SUPABASE_SECRET_KEY` must only be used in server-side environments.
 
 ---
 
@@ -572,7 +578,7 @@ Key details:
 
 ### Problem: Query returns empty array but data exists
 
-**Cause:** Row Level Security is blocking the query. RLS is enabled by default, and without policies, no rows are returned.
+**Cause:** Row Level Security is blocking the query. Once RLS is enabled on a table, no rows are returned without a matching policy.
 
 **Fix:**
 
@@ -598,9 +604,9 @@ ALTER TABLE your_table DISABLE ROW LEVEL SECURITY;
 **Fix:**
 
 1. Verify `SUPABASE_URL` matches the project in your dashboard
-2. Verify `SUPABASE_ANON_KEY` is the **anon** key (not the service role key) for client-side use
-3. Regenerate keys if compromised: **Settings** > **API** > **Regenerate**
-4. Make sure you are not accidentally using the JWT secret instead of the API key
+2. Verify `SUPABASE_PUBLISHABLE_KEY` is the **publishable** key (`sb_publishable_...`, not the secret key) for client-side use
+3. Rotate keys if compromised: **Settings** > **API Keys** > create a new key and delete the old one
+4. If you have an older project still on legacy `anon`/`service_role` JWT keys, migrate to publishable/secret keys -- legacy keys are being removed in late 2026
 
 ### Problem: CORS errors in the browser
 
@@ -614,8 +620,8 @@ ALTER TABLE your_table DISABLE ROW LEVEL SECURITY;
 ```js
 fetch(`${SUPABASE_URL}/rest/v1/posts`, {
   headers: {
-    'apikey': SUPABASE_ANON_KEY,
-    'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+    'apikey': SUPABASE_PUBLISHABLE_KEY,
+    'Authorization': `Bearer ${SUPABASE_PUBLISHABLE_KEY}`,
     'Content-Type': 'application/json',
   },
 });
@@ -646,9 +652,9 @@ WITH CHECK (bucket_id = 'your-bucket');
 **Fix:**
 
 1. Use the **Supavisor pooler** connection string instead of the direct connection:
-   - Go to **Settings** > **Database** > **Connection string**
+   - Click the **Connect** button at the top of the dashboard
    - Select **Mode: Transaction** for serverless environments
-   - The pooler URL uses port `6543` instead of `5432`
+   - The pooler URL uses port `6543` instead of `5432` (session mode stays on `5432`)
 
 2. Connection string format:
 ```
@@ -672,11 +678,11 @@ const pool = new Pool({
 
 ### Problem: Realtime subscription not receiving events
 
-**Cause:** Replication is not enabled for the table, or RLS is blocking the subscription.
+**Cause:** The table is not in the realtime publication, or RLS is blocking the subscription.
 
 **Fix:**
 
-1. Enable replication: **Database** > **Replication** > toggle on your table
+1. Enable realtime: **Database** > **Publications** > toggle on your table under `supabase_realtime`
 2. Or via SQL: `ALTER PUBLICATION supabase_realtime ADD TABLE your_table;`
 3. Make sure your RLS policies allow SELECT for the subscribing user
 4. Check that you are calling `.subscribe()` on the channel

--- a/guides/turso.md
+++ b/guides/turso.md
@@ -1,0 +1,514 @@
+# Turso
+
+> Set up a free SQLite-compatible edge database with Turso Cloud, connect from Node.js and Python, and sync a local replica.
+
+Turso Cloud is a managed SQLite platform (built on libSQL, the company's SQLite fork) that gives you cheap, fast databases you can create by the hundred -- one per user or per tenant is a normal pattern here. No acquisition, no pivot: Turso Cloud is still the product name. The company did rewrite SQLite from scratch in Rust (the engine is also called Turso, still pre-1.0 at v0.7.0-pre.13 as of 2026-06-25), and a next-generation Turso Cloud running that engine has been in private beta since 2026-04-08. Existing SQLite/libSQL databases keep running exactly as they do today and will never be moved to the new engine without user action.
+
+## Prerequisites
+
+- [ ] A [Turso account](https://turso.tech/) (created via CLI in Step 2, GitHub sign-in supported)
+- [ ] [Node.js](https://nodejs.org/) (a current LTS release, for Node.js usage)
+- [ ] [Python](https://www.python.org/downloads/) (a current release, for Python usage)
+- [ ] On Windows: [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) -- the Turso CLI has no native Windows build
+
+---
+
+## Step 1: Install the Turso CLI
+
+Latest CLI release is v1.0.29 (2026-06-18).
+
+**macOS (Homebrew):**
+
+```bash
+brew install tursodatabase/tap/turso
+```
+
+**macOS / Linux (install script):**
+
+```bash
+curl -sSfL https://get.tur.so/install.sh | bash
+```
+
+**Windows (WSL required -- the install script fails in PowerShell):**
+
+```bash
+wsl --install
+# restart, then inside WSL:
+curl -sSfL https://get.tur.so/install.sh | bash
+```
+
+Verify:
+
+```bash
+turso --version
+```
+
+---
+
+## Step 2: Sign Up and Log In
+
+```bash
+# New account -- opens the browser to complete signup
+turso auth signup
+
+# Existing account
+turso auth login
+```
+
+---
+
+## Step 3: Create a Database
+
+```bash
+turso db create my-db
+```
+
+Inspect it:
+
+```bash
+# Prints name, ID, libSQL server version, group, size, and location
+turso db show my-db
+```
+
+Open an interactive SQL shell and create a table:
+
+```bash
+turso db shell my-db
+```
+
+```sql
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    email TEXT UNIQUE NOT NULL
+);
+.quit
+```
+
+### Seeding options
+
+`turso db create` can start from existing data instead of empty:
+
+```bash
+# Import a local SQLite file (2 GB max)
+turso db create my-db --from-file ./local.db
+
+# Copy another Turso database
+turso db create my-db-copy --from-db my-db
+
+# Point-in-time restore (RFC3339 timestamp, requires --from-db)
+turso db create my-db-restored --from-db my-db --timestamp 2026-07-01T00:00:00Z
+
+# Import a CSV into a named table
+turso db create my-db --from-csv data.csv --csv-table-name users
+```
+
+Other useful flags: `--from-dump`, `--from-dump-url`, `--group`, `--size-limit` (bytes, units accepted), `--enable-extensions` (experimental), `-w/--wait`.
+
+---
+
+## Step 4: Get the URL and an Auth Token
+
+Your app needs two values: the database URL and an auth token.
+
+```bash
+# libSQL connection URL (libsql://<database>-<org>.turso.io)
+turso db show my-db --url
+
+# HTTP URL variant, if you need it
+turso db show my-db --http-url
+
+# Full-access token with the default expiration
+turso db tokens create my-db
+
+# Read-only token that expires in 7 days
+turso db tokens create my-db --read-only --expiration 7d
+
+# Token that never expires (fine for hobby projects, rotate for anything serious)
+turso db tokens create my-db --expiration never
+```
+
+Put both in a `.env` file (and add `.env` to `.gitignore`):
+
+```bash
+# .env
+TURSO_DATABASE_URL=libsql://my-db-yourorg.turso.io
+TURSO_AUTH_TOKEN=eyJhbGciOiJFZERTQSIs...
+```
+
+---
+
+## Use in Node.js
+
+Two official packages. Pick based on where your code runs:
+
+- **`@tursodatabase/serverless`** (1.2.3 as of 2026-07-06) -- the current quickstart recommendation for remote databases. Fetch-based, zero native dependencies, works on Cloudflare Workers, Vercel Edge, and Deno Deploy.
+- **`@libsql/client`** (0.17.4) -- the classic client. Production-ready, supports Drizzle and Prisma, and is what you want for ORM integration, embedded replicas, or existing codebases. Ships web/edge builds automatically via conditional exports.
+
+There is also `@tursodatabase/database` (0.6.1) for local/embedded use in Node.js, Electron, mobile, and IoT.
+
+### Option A: @tursodatabase/serverless
+
+```bash
+npm install @tursodatabase/serverless
+```
+
+```js
+import { connect } from "@tursodatabase/serverless";
+
+const conn = connect({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+const stmt = await conn.prepare("SELECT * FROM users");
+const rows = await stmt.all();
+console.log(rows);
+```
+
+### Option B: @libsql/client
+
+```bash
+npm install @libsql/client
+```
+
+```js
+import { createClient } from "@libsql/client";
+
+const client = createClient({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+// Create
+await client.execute({
+  sql: "INSERT INTO users (name, email) VALUES (?, ?)",
+  args: ["Sagar", "sagar@example.com"],
+});
+
+// Read
+const result = await client.execute("SELECT * FROM users");
+console.log(result.rows);
+```
+
+---
+
+## Use in Python
+
+The primary package is now `pyturso` (0.6.1 on PyPI) -- a sqlite3-style API for local and synced databases:
+
+```bash
+uv add pyturso
+# or: pip install pyturso
+```
+
+```python
+import turso
+
+db = turso.connect("app.db")
+cur = db.cursor()
+cur.execute("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)")
+cur.execute("INSERT INTO users (name) VALUES (?)", ("Sagar",))
+db.commit()
+
+rows = cur.execute("SELECT * FROM users").fetchall()
+print(rows)
+```
+
+For a local database that syncs with Turso Cloud, use `turso.sync.connect()` with explicit `push()`/`pull()` -- the docs recommend this for new projects:
+
+```python
+import os
+import turso
+
+db = turso.sync.connect(
+    "local.db",
+    url=os.environ["TURSO_DATABASE_URL"],
+    auth_token=os.environ["TURSO_AUTH_TOKEN"],
+)
+
+db.pull()   # fetch remote changes
+# ... local reads and writes ...
+db.push()   # send local changes to Turso Cloud
+```
+
+For direct remote access over HTTP (no local file) and embedded replicas, the `libsql` package is fully supported in production:
+
+```bash
+pip install libsql
+```
+
+```python
+import os
+import libsql
+
+conn = libsql.connect(
+    os.environ["TURSO_DATABASE_URL"],
+    auth_token=os.environ["TURSO_AUTH_TOKEN"],
+)
+print(conn.execute("SELECT * FROM users").fetchall())
+```
+
+---
+
+## Drizzle ORM Integration
+
+```bash
+npm i drizzle-orm @libsql/client dotenv
+npm i -D drizzle-kit
+```
+
+Define a schema in `src/db/schema.ts` using `sqliteTable`:
+
+```ts
+import { sqliteTable, integer, text } from "drizzle-orm/sqlite-core";
+
+export const users = sqliteTable("users", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+});
+```
+
+Create `drizzle.config.ts` with the `turso` dialect:
+
+```ts
+import "dotenv/config";
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  dialect: "turso",
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+  dbCredentials: {
+    url: process.env.TURSO_DATABASE_URL!,
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  },
+});
+```
+
+Initialize the client in `src/db/index.ts`:
+
+```ts
+import { drizzle } from "drizzle-orm/libsql";
+import { createClient } from "@libsql/client";
+import * as schema from "./schema";
+
+const client = createClient({
+  url: process.env.TURSO_DATABASE_URL!,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+export const db = drizzle(client, { schema });
+```
+
+Generate and apply migrations:
+
+```bash
+npx drizzle-kit generate   # write SQL migrations from the schema
+npx drizzle-kit migrate    # apply them to the database
+npx drizzle-kit studio     # browse data in a local UI
+```
+
+```ts
+// Query with Drizzle
+import { db } from "./db";
+import { users } from "./db/schema";
+
+await db.insert(users).values({ name: "Sagar", email: "sagar@example.com" });
+const all = await db.select().from(users);
+```
+
+---
+
+## Embedded Replicas
+
+Embedded replicas keep a local SQLite file next to your app: reads are always served locally (microsecond latency), writes are forwarded to the remote primary and then applied locally. The writing replica gets read-your-writes without calling `sync()`. Supported SDKs: TypeScript/JS, Go, Rust, PHP, Laravel.
+
+```js
+import { createClient } from "@libsql/client";
+
+const client = createClient({
+  url: "file:path/to/db-file.db",                          // local file for reads
+  syncUrl: "libsql://[databaseName]-[organizationSlug].turso.io", // remote primary
+  authToken: process.env.TURSO_AUTH_TOKEN,
+  syncInterval: 60,                                        // auto-sync every 60 s
+});
+
+// Or sync manually instead of on an interval
+await client.sync();
+```
+
+Two constraints to respect:
+
+- Embedded replicas need a persistent disk. They work on Fly, Railway, Render, Koyeb, and Akamai (official guides exist), but NOT in Vercel or Lambda functions -- see Troubleshooting.
+- Write transactions that contain reads are routed to the remote primary, not executed locally.
+
+> **Newer alternative:** Turso Sync (announced 2026-04-24) offers local-first writes with explicit `push()`/`pull()` and uses much less bandwidth than embedded replicas. The docs now recommend it over embedded replicas for new projects -- see `/sync/usage` in the Turso docs. The Python example above already uses it.
+
+---
+
+## Local Development
+
+`turso dev` starts a local libSQL server with extension support:
+
+```bash
+# Ephemeral -- data is lost when the server stops
+turso dev
+
+# Persisted to a file
+turso dev --db-file local.db
+```
+
+Or skip the server entirely and point your client at a plain file URL:
+
+```js
+const client = createClient({ url: "file:local.db" });
+```
+
+Seed local from production:
+
+```bash
+turso db shell your-database .dump > dump.sql
+cat dump.sql | sqlite3 local.db
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `TURSO_DATABASE_URL` | libSQL URL from `turso db show my-db --url` | `libsql://my-db-yourorg.turso.io` |
+| `TURSO_AUTH_TOKEN` | Token from `turso db tokens create my-db` | `eyJhbGciOiJFZERTQSIs...` |
+
+Set them on your deployment platform:
+
+- **Vercel:** Project Settings > Environment Variables
+- **Render:** Service > Environment tab
+- **Local:** `.env` file (in `.gitignore`), loaded with `dotenv` or `node --env-file=.env`
+
+```bash
+# Regenerate the token anytime -- old tokens keep working until they expire
+turso db tokens create my-db --expiration 7d
+```
+
+---
+
+## Custom Domain
+
+Turso does not support custom domains for database connections. Connect via the provided `libsql://<database>-<org>.turso.io` URL.
+
+---
+
+## Free Tier Info
+
+| Feature | Free ($0/month) |
+|---------|-----------------|
+| **Databases** | 100 |
+| **Storage** | 5 GB |
+| **Rows read** | 500M/month |
+| **Rows written** | 10M/month |
+| **Syncs** | 3 GB/month |
+| **Point-in-time restore** | 1 day |
+| **Branching + restores** | No additional charge (true on every plan) |
+
+Paid tiers:
+
+| Plan | Price | Storage | Rows read | Rows written | Syncs | Restore | Extras |
+|------|-------|---------|-----------|--------------|-------|---------|--------|
+| **Developer** | $4.99/mo | 9 GB | 2.5B | 25M | 10 GB | 10 days | Unlimited databases |
+| **Scaler** | $24.92/mo | 24 GB | 100B | 100M | - | 30 days | Teams |
+| **Pro** | $416.58/mo | 50 GB | 250B | 250M | 100 GB | 90 days | SSO, BYOK, HIPAA, SOC2 |
+
+Key details:
+
+- Since 2026-05-03, all paid plans include unlimited databases active at any time (billing previously scaled with databases receiving at least one query per cycle).
+- Listed overage rates: +$0.75/GB storage, +$1 per billion rows read, +$1 per million rows written, +$0.35/GB syncs. On quota-limited plans, queries that exceed limits fail with a `BLOCKED` error instead of silently billing overage -- see Troubleshooting.
+- Database branching and point-in-time restores are free on every plan, so branch-per-PR workflows cost nothing extra.
+- Manage your plan from the CLI:
+
+```bash
+turso plan show      # current plan and usage
+turso plan select    # switch plans
+turso plan upgrade   # upgrade
+turso org billing    # open billing
+```
+
+---
+
+## Troubleshooting
+
+### Problem: Queries fail with a BLOCKED error
+
+**Cause:** You exceeded a plan quota (rows read, rows written, or storage) on a quota-limited plan. Turso rejects the query outright -- there is no silent overage billing.
+
+**Fix:**
+
+```bash
+# Check where you stand
+turso plan show
+
+# Upgrade, or wait for the billing cycle to reset
+turso plan upgrade
+```
+
+### Problem: Rows-read usage is way higher than the rows you actually return
+
+**Cause:** "Rows read" counts row SCANS, not returned rows. Aggregates (`COUNT`, `AVG`, `MIN`, `MAX`, `SUM`) scan every considered row, unindexed queries trigger full table scans, and even rolled-back transactions bill their rows written.
+
+**Fix:** Add indexes so queries avoid full scans:
+
+```sql
+CREATE INDEX idx_users_email ON users (email);
+```
+
+Also note: `VACUUM` is currently disabled in Turso, and storage is measured in 4 KB pages via `dbstat`.
+
+### Problem: HTTP 401, 402, or 409 from the API
+
+**Cause:** 401 means an invalid or expired auth token. 402 Payment Required means no active subscription. 409 Conflict means the resource (e.g., a database name) already exists.
+
+**Fix:**
+
+```bash
+# 401: mint a fresh token and update your env var
+turso db tokens create my-db
+
+# 409: pick a different database name
+turso db create my-db-2
+```
+
+### Problem: Embedded replica fails on Vercel or AWS Lambda
+
+**Cause:** Embedded replicas need a persistent filesystem to store the local database file. Serverless function platforms do not provide one.
+
+**Fix:** Use a remote-only connection (`@tursodatabase/serverless` or `@libsql/client` with just `url` + `authToken`) on serverless platforms. Run embedded replicas on hosts with a real disk -- Fly, Railway, Render, Koyeb, and Akamai have official guides. And never open the local replica file with another connection while it is syncing; that risks corruption.
+
+### Problem: Migration tool fails writing PRAGMA user_version
+
+**Cause:** On Turso Cloud, `PRAGMA user_version` and `application_id` are read-only, and `busy_timeout` and `journal_mode` are not supported (concurrency and journaling are managed server-side). Migration tools that track state via `PRAGMA user_version` fail to write it.
+
+**Fix:** Track schema state in a table instead:
+
+```sql
+CREATE TABLE IF NOT EXISTS _schema_version (version INTEGER NOT NULL);
+```
+
+Or use a migration tool that already does this (drizzle-kit tracks migrations in its own table).
+
+### Problem: CLI install script fails on Windows PowerShell
+
+**Cause:** The turso CLI has no native Windows build -- no Scoop, no winget, no .exe.
+
+**Fix:**
+
+```powershell
+wsl --install
+```
+
+Then restart, enter `wsl`, and run the install script inside WSL:
+
+```bash
+curl -sSfL https://get.tur.so/install.sh | bash
+```

--- a/guides/upstash.md
+++ b/guides/upstash.md
@@ -7,8 +7,8 @@ Upstash provides serverless Redis with a unique REST API, making it ideal for ed
 ## Prerequisites
 
 - [ ] An [Upstash account](https://console.upstash.com/) (sign up with GitHub, Google, or email)
-- [ ] [Node.js 18+](https://nodejs.org/) (for JavaScript usage)
-- [ ] [Python 3.9+](https://www.python.org/downloads/) (for Python usage)
+- [ ] [Node.js 22+](https://nodejs.org/) (for JavaScript usage)
+- [ ] [Python 3.12+](https://www.python.org/downloads/) (for Python usage)
 
 ---
 
@@ -18,12 +18,12 @@ Upstash provides serverless Redis with a unique REST API, making it ideal for ed
 2. Click **Create Database**
 3. Configure:
    - **Name:** `my-cache`
-   - **Type:** Regional (lower latency) or Global (multi-region replication)
-   - **Region:** Select the one closest to your deployment (e.g., `US-East-1` for Vercel/Render)
-   - **TLS:** Enabled (recommended)
+   - **Primary Region:** Select the one closest to your deployment (e.g., `US-East-1` for Vercel/Render)
+   - **Read Regions:** Optional -- add read replicas in regions close to your other traffic
+   - **Plan:** Free to start
 4. Click **Create**
 
-The database is provisioned instantly.
+The database is provisioned instantly. TLS is always enabled -- there is no toggle. (The old Regional database type is deprecated; all new databases use the current region-plus-replicas model.)
 
 ---
 
@@ -444,12 +444,14 @@ await qstash.publishJSON({
 
 ### Scheduled (Cron) Messages
 
+Recurring messages use the Schedules API, not `publishJSON`:
+
 ```js
 // Run every hour
-await qstash.publishJSON({
-  url: 'https://yourapp.com/api/cleanup',
-  body: { task: 'cleanup-expired-sessions' },
+await qstash.schedules.create({
+  destination: 'https://yourapp.com/api/cleanup',
   cron: '0 * * * *',  // Standard cron syntax
+  body: JSON.stringify({ task: 'cleanup-expired-sessions' }),
 });
 ```
 
@@ -509,12 +511,12 @@ UPSTASH_REDIS_REST_TOKEN=AXXXaaaBBBcccDDDeee...
 
 ### Vercel Integration
 
-Upstash has a first-party Vercel integration that auto-provisions a Redis database and sets environment variables:
+Upstash is a native Vercel Marketplace integration that auto-provisions a Redis database and sets environment variables:
 
 1. Go to [vercel.com/integrations/upstash](https://vercel.com/integrations/upstash)
-2. Click **Add Integration**
-3. Select your Vercel project
-4. Upstash creates a database and sets `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` automatically
+2. Click **Install**, then create a new Upstash account (choose product, database name, region, plan) or link an existing one
+3. Connect the database to your Vercel project
+4. Upstash sets `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` automatically -- redeploy your project for the new env vars to take effect
 
 ---
 
@@ -522,28 +524,30 @@ Upstash has a first-party Vercel integration that auto-provisions a Redis databa
 
 | Feature | Free Tier |
 |---------|-----------|
-| **Commands** | 10,000/day |
+| **Commands** | 500,000/month |
 | **Storage** | 256 MB |
+| **Bandwidth** | 10 GB/month |
 | **Concurrent connections** | 100 |
-| **Databases** | 1 |
-| **Max request size** | 1 MB |
-| **QStash messages** | 500/day |
+| **Databases** | 10 |
+| **Max request size** | 10 MB |
+| **QStash messages** | 1,000/day |
 
 Key details:
-- The free tier resets daily at midnight UTC
+- The command quota is monthly, not daily
 - No credit card required
 - Scales to zero -- no charges when idle
 - Global replication is available on paid plans
 - Data persists (not ephemeral like some Redis providers)
-- The 10K daily command limit includes all operations (GET, SET, etc.)
+- The 500K monthly command limit includes all operations (GET, SET, etc.)
+- Beyond 10 free databases, additional ones cost $0.50 per database (up to 100)
 
 ---
 
 ## Troubleshooting
 
-### Problem: "ERR max daily request limit exceeded"
+### Problem: "ERR max requests limit exceeded"
 
-**Cause:** You have exceeded the 10,000 commands/day free tier limit.
+**Cause:** You have exceeded the 500,000 commands/month free tier limit.
 
 **Fix:**
 

--- a/guides/vercel.md
+++ b/guides/vercel.md
@@ -2,14 +2,14 @@
 
 > Deploy frontend apps and serverless functions with zero configuration on Vercel.
 
-Vercel is the company behind Next.js and provides a platform optimized for frontend frameworks. It supports automatic deployments from Git, serverless functions, edge functions, and preview deployments for every pull request.
+Vercel is the company behind Next.js and provides a platform optimized for frontend frameworks. It supports automatic deployments from Git, serverless functions (running on Fluid compute by default, billed on active CPU), edge functions, and preview deployments for every pull request. The Hobby (free) plan includes 100 GB/month data transfer, 1M function invocations/month, and 4 hours/month of active CPU.
 
 ## Prerequisites
 
 - [ ] A [Vercel account](https://vercel.com/signup) (sign up with GitHub for easiest setup)
 - [ ] [Git](https://git-scm.com/downloads) installed locally
-- [ ] [Node.js 18+](https://nodejs.org/)
-- [ ] (Optional) [Vercel CLI](https://vercel.com/docs/cli): `npm i -g vercel`
+- [ ] [Node.js 20+](https://nodejs.org/) (22+ recommended)
+- [ ] (Optional) [Vercel CLI](https://vercel.com/docs/cli): `npm i -g vercel` or `pnpm add -g vercel`
 
 ## Deploy Next.js
 
@@ -40,6 +40,8 @@ git push -u origin main
 5. Click **Deploy**
 
 Your app is live in under a minute. Every push to `main` triggers a new production deploy. Every pull request gets a unique preview URL.
+
+> Tip: to stop bot branches (Renovate, Dependabot) and every feature branch from spinning up preview deployments, set the project's **Ignored Build Step** (Settings > Git) to a command that exits non-zero for any ref other than the branches you want built. Skipped refs spend no build minutes and create no preview URL.
 
 ### Alternative: Deploy via CLI
 
@@ -82,7 +84,7 @@ That's it. No `base` path configuration needed (unlike GitHub Pages).
 
 ## Serverless Functions
 
-Vercel supports serverless functions out of the box. Create files in the `api/` directory at your project root.
+Vercel supports serverless functions out of the box. Create files in the `api/` directory at your project root. Available Node.js runtimes are 24.x (default), 22.x, and 20.x -- set in **Settings** > **Build and Deployment** or via `engines.node` in `package.json`.
 
 ### Example: Node.js API Route
 
@@ -127,6 +129,19 @@ export async function GET(request) {
 
 These are deployed automatically as serverless functions on Vercel.
 
+### Python Functions (FastAPI)
+
+Vercel also runs Python serverless functions. A FastAPI app deploys with a three-line wrapper in `api/index.py`:
+
+```python
+from mangum import Mangum
+from myapp.main import app
+
+handler = Mangum(app, lifespan="off")
+```
+
+plus a `vercel.json` that routes all paths to it. Pin the Python runtime with a `PYTHON_VERSION` env var in the dashboard. Gotcha: FastAPI `BackgroundTasks` are unreliable on serverless -- run post-request work synchronously or hand it to a queue.
+
 ---
 
 ## Environment Variables
@@ -163,6 +178,7 @@ vercel env ls
 - Variables prefixed with `NEXT_PUBLIC_` (Next.js) or `VITE_` (Vite) are exposed to the browser. Never put secrets in these.
 - Server-side environment variables (no prefix) are only available in API routes and serverless functions.
 - After changing env vars, you must redeploy for changes to take effect.
+- If your build reads a database (e.g., Next.js `generateStaticParams` querying it during `next build`), the same variables production needs at runtime must also exist at build time -- in the Vercel project env and in any CI that runs the build. `NEXT_PUBLIC_*` / `VITE_*` values are baked into the bundle at build time, so their build-time value is what ships.
 
 ---
 
@@ -176,19 +192,21 @@ vercel env ls
 
 ### Step 2: Configure DNS
 
-Vercel will show you the required DNS records. Typically:
+Vercel shows the exact DNS records for your project in **Settings** > **Domains** -- copy those values rather than hardcoding ones from a tutorial. Vercel now issues project-specific values: apex domains get a dashboard-provided A record (new domains are commonly issued `216.198.79.1`) and subdomains get a unique per-project CNAME (e.g., `<hash>.vercel-dns-017.com`). The shape looks like:
 
 **For apex domain (`yourdomain.com`):**
 
 | Type | Name | Value |
 |------|------|-------|
-| A | @ | 76.76.21.21 |
+| A | @ | (A record shown in your project's Domains settings) |
 
 **For subdomain (`www.yourdomain.com`):**
 
 | Type | Name | Value |
 |------|------|-------|
-| CNAME | www | cname.vercel-dns.com |
+| CNAME | www | (unique CNAME shown in your project's Domains settings) |
+
+The legacy values (`76.76.21.21` / `cname.vercel-dns.com`) continue to work for existing setups, but Vercel recommends the project-specific values for new domains.
 
 ### Step 3: Verify and SSL
 
@@ -258,12 +276,30 @@ Or trigger a manual redeploy from the Vercel dashboard.
 3. Wait up to 48 hours for propagation (usually much faster)
 4. Try removing and re-adding the domain in Vercel
 
+### Problem: Browser reports a CORS error calling your Vercel API
+
+**Cause:** Often not a CORS misconfiguration at all -- CORS headers are missing on unhandled 500 responses, so a server error surfaces in the browser as "CORS error".
+
+**Fix:**
+
+1. Check the function logs first (**Deployments** > select deploy > **Functions** tab) for an exception
+2. Only then verify your CORS config explicitly allows the frontend's origin (exact scheme + host)
+
+### Problem: Uploads fail with 413 (request body too large)
+
+**Cause:** Vercel caps serverless request bodies at ~4.5 MB at the platform level. App-level limits (e.g., Next.js `experimental.serverActions.bodySizeLimit`) apply independently -- raising one does not lift the other.
+
+**Fix:**
+
+1. Upload large batches a few files at a time so each request stays under ~4.5 MB
+2. For big files, upload directly from the client to object storage (S3/R2 presigned URLs) instead of through the function
+
 ### Problem: Serverless function timeout
 
-**Cause:** Function exceeds the execution time limit (10s on Hobby plan, 60s on Pro).
+**Cause:** Function exceeds the max duration limit. With Fluid compute (enabled by default for new projects), functions default to 300s (5 minutes) on all plans; Hobby maxes out at 300s, Pro/Enterprise can raise `maxDuration` up to 800s (1800s in beta via per-function config).
 
 **Fix:**
 
 1. Optimize the function -- reduce external API calls, use caching
-2. For long-running tasks, consider using Vercel's background functions or a dedicated backend
-3. Upgrade to Pro for longer timeouts if needed
+2. For workloads needing unlimited execution time, use Vercel Workflows (code can pause/resume and maintain state without duration limits) or a dedicated backend
+3. On Pro, raise `maxDuration` in the function config (up to 800s) if needed


### PR DESCRIPTION
## What does this PR add or change?

Full July 2026 refresh of the repo plus 11 new guides from the open issue backlog.

**Refresh (all 26 existing guides + README):** every price, free tier limit, CLI command, dashboard step label, runtime version, and external link was re-verified against official docs and pricing pages. The big corrections:

- Fly.io no longer has a free tier -- pay-as-you-go only (~$2/mo smallest machine)
- AWS replaced the 12-month free tier with a credits plan ($100-$200, 6 months) in July 2025 -- affects ECS and Amplify guides
- Netlify moved to credit-based plans (300 credits/mo free, Personal $9/mo)
- Upstash free tier is 500K commands/mo (was 10K/day); Neon is 100 CU-hrs/project (was 191 compute hrs)
- Railway recurring $5 credit is now a one-time trial; Nixpacks -> Railpack; railway.app -> railway.com
- MongoDB Atlas M2/M5 deprecated in favor of Flex ($8-$30/mo)
- Supabase anon/service_role keys -> publishable/secret keys
- Node 18/20 are EOL -> prerequisites now Node 22+ (24 LTS); Python 3.9 EOL -> 3.12+
- Express 4 -> 5, FastAPI standard install + fastapi CLI, psycopg2 -> psycopg 3, Motor -> PyMongo Async
- GitHub Actions majors: checkout@v7, setup-node@v6, setup-python@v6, Pages actions v5/v6
- Docker guide: node:24-alpine, npm ci --omit=dev, BuildKit cache mounts
- README stats, tables, decision tree, and cost comparison rebuilt from the refreshed guides, with a "Prices last verified: 2026-07-06" note

**New guides (closes the issue backlog):**

- Frameworks: SvelteKit (#1), Astro (#2), Angular (#7), NestJS (#8), Go/Gin (#9), Ruby on Rails (#10)
- Databases: Turso (#3), CockroachDB (#4)
- Platforms: Hetzner Cloud (#5), Coolify (#6)
- Reference: Monitoring & Logging (#15) -- UptimeRobot, Better Stack, Sentry, Axiom, Grafana Cloud, healthchecks.io free tiers + webhook alerting

Closes #1, closes #2, closes #3, closes #4, closes #5, closes #6, closes #7, closes #8, closes #9, closes #10, closes #15

## Type of Change

- [x] New platform guide (`guides/`)
- [x] New framework guide (`frameworks/`)
- [x] New database guide (`guides/`)
- [x] Improvement to existing guide
- [x] Bug fix (broken link, typo, incorrect command)

## Checklist

- [x] I followed the [guide template](../CONTRIBUTING.md#guide-template)
- [ ] I tested every command in this guide on a fresh project
- [x] I included all required sections (Prerequisites, Steps, Environment Variables, Custom Domain, Troubleshooting)
- [x] I added the guide to the appropriate table in `README.md` (if new guide)
- [x] I used kebab-case for the filename
- [x] I included free tier information where applicable
- [x] I included actual commands, not just descriptions

## Platform/Framework Details

- **Name:** 11 new (SvelteKit, Astro, Angular, NestJS, Go/Gin, Rails, Turso, CockroachDB, Hetzner, Coolify, Monitoring) + 26 refreshed
- **Category:** Platform / Framework / Database / Reference
- **Free tier available:** Yes (documented per guide; Fly.io and Hetzner are paid and marked as such)

## Testing

Facts verified against live official docs and pricing pages (2026-07-06), not run end-to-end on fresh projects -- flagging the untested checklist item honestly. Commands come from current official quickstarts. Style checks run locally: zero em/en dashes, zero emojis, markdown tables intact, README tables cross-checked against guide free-tier sections, all relative links resolve.

- **OS:** Windows 11 (docs-only change)
- **Node/Python/etc. version:** n/a
- **Date last tested:** 2026-07-06

## Additional Notes

Review priority: README cost tables and the Fly.io/AWS/Netlify free tier rewrites carry the most reader impact. The monitoring guide's Slack webhook example was reworded after GitHub push protection flagged the placeholder URL pattern.
